### PR TITLE
refactor(web/teacher): error page html tag

### DIFF
--- a/web/teacher/src/layouts/error.vue
+++ b/web/teacher/src/layouts/error.vue
@@ -1,15 +1,14 @@
 <template>
   <v-app>
-    <v-content>
-      <v-container>
-        <v-layout column align-center>
-          <h1>不明なエラーが発生しました</h1>
+    <v-main>
+      <v-row column align-center>
+        <v-col class="d-flex flex-column text-center px-8">
           <v-img src="/error-500.png" />
-
+          <h2 class="my-4">不明なエラーが発生しました</h2>
           <v-btn @click="handleClick">ホームへ戻る</v-btn>
-        </v-layout>
-      </v-container>
-    </v-content>
+        </v-col>
+      </v-row>
+    </v-main>
   </v-app>
 </template>
 


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
エラーページのHTMLタグが、Vuetify 1.xで定義されているコンポーネント名を使って書いていたので、Vuetify 2.xのコンポーネントへ置き換えました

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
