### PR TITLE
feat(gateway): add get auth api mock

### DIFF
--- a/api/internal/gateway/cmd/teacher/router.go
+++ b/api/internal/gateway/cmd/teacher/router.go
@@ -10,8 +10,16 @@ func newRouter(reg *registry, opts ...gin.HandlerFunc) *gin.Engine {
 	rt := gin.Default()
 	rt.Use(opts...)
 
-	reg.v1.AdminRoutes(rt.Group(""))
-	reg.v1.AuthRoutes(rt.Group(""))
+	// auth required routes
+	authV1Group := rt.Group("")
+	authV1Group.Use(reg.v1.Authentication())
+	reg.v1.AuthRoutes(authV1Group)
+
+	// TODO: auth required with admin role routes
+	adminV1Group := rt.Group("")
+	reg.v1.AdminRoutes(adminV1Group)
+
+	// public routes
 	reg.v1.NoAuthRoutes(rt.Group(""))
 
 	// other routes

--- a/api/internal/gateway/teacher/v1/entity/auth.go
+++ b/api/internal/gateway/teacher/v1/entity/auth.go
@@ -1,6 +1,6 @@
 package entity
 
-type Teacher struct {
+type Auth struct {
 	ID            string `json:"id"`            // 講師ID
 	LastName      string `json:"lastName"`      // 姓
 	FirstName     string `json:"firstName"`     // 名
@@ -8,14 +8,4 @@ type Teacher struct {
 	FirstNameKana string `json:"firstNameKana"` // 名(かな)
 	Mail          string `json:"mail"`          // メールアドレス
 	Role          Role   `json:"role"`          // 権限
-	CreatedAt     string `json:"createdAt"`     // 登録日時
-	UpdatedAt     string `json:"updatedAt"`     // 更新日時
 }
-
-type Role int32
-
-const (
-	RoleUnknown       Role = 0
-	RoleTeacher       Role = 1
-	RoleAdministrator Role = 2
-)

--- a/api/internal/gateway/teacher/v1/handler/api_test.go
+++ b/api/internal/gateway/teacher/v1/handler/api_test.go
@@ -27,6 +27,8 @@ import (
 	"golang.org/x/sync/singleflight"
 )
 
+var idMock = "kSByoE6FetnPs5Byk3a9Zx"
+
 type mocks struct {
 	userService *mock_user.MockUserServiceClient
 }
@@ -130,6 +132,7 @@ func newHTTPRequest(t *testing.T, method, path string, body interface{}) *http.R
 	require.NoError(t, err, err)
 
 	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("userId", idMock)
 	return req
 }
 
@@ -161,6 +164,7 @@ func newMultipartRequest(t *testing.T, method, path, field string) *http.Request
 	require.NoError(t, err, err)
 
 	req.Header.Add("Content-Type", writer.FormDataContentType())
+	req.Header.Add("userId", idMock)
 	return req
 }
 

--- a/api/internal/gateway/teacher/v1/handler/auth.go
+++ b/api/internal/gateway/teacher/v1/handler/auth.go
@@ -4,32 +4,25 @@ import (
 	"net/http"
 
 	"github.com/calmato/shs-web/api/internal/gateway/teacher/v1/entity"
-	"github.com/calmato/shs-web/api/internal/gateway/teacher/v1/request"
 	"github.com/calmato/shs-web/api/internal/gateway/teacher/v1/response"
 	"github.com/gin-gonic/gin"
 )
 
 // mock
-func (h *apiV1Handler) CreateTeacher(ctx *gin.Context) {
-	req := &request.CreateTeacherRequest{}
-	if err := ctx.BindJSON(req); err != nil {
-		badRequest(ctx, err)
-		return
-	}
+func (h *apiV1Handler) GetAuth(ctx *gin.Context) {
+	teacherID := getTeacherID(ctx)
 
 	// TODO: get teacher
 
-	res := &response.TeacherResponse{
-		Teacher: &entity.Teacher{
-			ID:            "123456789012345678901",
+	res := &response.AuthResponse{
+		Auth: &entity.Auth{
+			ID:            teacherID,
 			LastName:      "中村",
 			FirstName:     "広大",
 			LastNameKana:  "なかむら",
 			FirstNameKana: "こうだい",
 			Mail:          "teacher-test001@calmato.jp",
 			Role:          entity.Role(entity.RoleTeacher),
-			CreatedAt:     h.now().String(),
-			UpdatedAt:     h.now().String(),
 		},
 	}
 	ctx.JSON(http.StatusOK, res)

--- a/api/internal/gateway/teacher/v1/handler/auth.go
+++ b/api/internal/gateway/teacher/v1/handler/auth.go
@@ -22,7 +22,7 @@ func (h *apiV1Handler) GetAuth(ctx *gin.Context) {
 			LastNameKana:  "なかむら",
 			FirstNameKana: "こうだい",
 			Mail:          "teacher-test001@calmato.jp",
-			Role:          entity.Role(entity.RoleTeacher),
+			Role:          entity.RoleTeacher,
 		},
 	}
 	ctx.JSON(http.StatusOK, res)

--- a/api/internal/gateway/teacher/v1/handler/auth_test.go
+++ b/api/internal/gateway/teacher/v1/handler/auth_test.go
@@ -31,7 +31,7 @@ func TestGetAuth(t *testing.T) {
 						LastNameKana:  "なかむら",
 						FirstNameKana: "こうだい",
 						Mail:          "teacher-test001@calmato.jp",
-						Role:          entity.Role(entity.RoleTeacher),
+						Role:          entity.RoleTeacher,
 					},
 				},
 			},

--- a/api/internal/gateway/teacher/v1/handler/auth_test.go
+++ b/api/internal/gateway/teacher/v1/handler/auth_test.go
@@ -6,47 +6,32 @@ import (
 	"testing"
 
 	"github.com/calmato/shs-web/api/internal/gateway/teacher/v1/entity"
-	"github.com/calmato/shs-web/api/internal/gateway/teacher/v1/request"
 	"github.com/calmato/shs-web/api/internal/gateway/teacher/v1/response"
-	"github.com/calmato/shs-web/api/pkg/jst"
 	"github.com/golang/mock/gomock"
 )
 
-func TestCreateTeacher(t *testing.T) {
+func TestGetAuth(t *testing.T) {
 	t.Parallel()
-	now := jst.Now()
 	tests := []struct {
 		name   string
 		setup  func(ctx context.Context, t *testing.T, mocks *mocks, ctrl *gomock.Controller)
-		req    *request.CreateTeacherRequest
+		userID string
 		expect *testResponse
 	}{
 		{
 			name:  "success",
 			setup: func(ctx context.Context, t *testing.T, mocks *mocks, ctrl *gomock.Controller) {},
-			req: &request.CreateTeacherRequest{
-				LastName:             "中村",
-				FirstName:            "広大",
-				LastNameKana:         "なかむら",
-				FirstNameKana:        "こうだい",
-				Mail:                 "teacher-test001@calmato.jp",
-				Role:                 int32(entity.RoleTeacher),
-				Password:             "12345678",
-				PasswordConfirmation: "12345678",
-			},
 			expect: &testResponse{
 				code: http.StatusOK,
-				body: &response.TeacherResponse{
-					Teacher: &entity.Teacher{
-						ID:            "123456789012345678901",
+				body: &response.AuthResponse{
+					Auth: &entity.Auth{
+						ID:            idMock,
 						LastName:      "中村",
 						FirstName:     "広大",
 						LastNameKana:  "なかむら",
 						FirstNameKana: "こうだい",
 						Mail:          "teacher-test001@calmato.jp",
 						Role:          entity.Role(entity.RoleTeacher),
-						CreatedAt:     now.String(),
-						UpdatedAt:     now.String(),
 					},
 				},
 			},
@@ -57,9 +42,9 @@ func TestCreateTeacher(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			const path = "/v1/teachers"
-			req := newHTTPRequest(t, http.MethodPost, path, tt.req)
-			testHTTP(t, tt.setup, tt.expect, req, withNow(now))
+			const path = "/v1/me"
+			req := newHTTPRequest(t, http.MethodGet, path, nil)
+			testHTTP(t, tt.setup, tt.expect, req)
 		})
 	}
 }

--- a/api/internal/gateway/teacher/v1/handler/teacher.go
+++ b/api/internal/gateway/teacher/v1/handler/teacher.go
@@ -27,7 +27,7 @@ func (h *apiV1Handler) CreateTeacher(ctx *gin.Context) {
 			LastNameKana:  "なかむら",
 			FirstNameKana: "こうだい",
 			Mail:          "teacher-test001@calmato.jp",
-			Role:          entity.Role(entity.RoleTeacher),
+			Role:          entity.RoleTeacher,
 			CreatedAt:     h.now().String(),
 			UpdatedAt:     h.now().String(),
 		},

--- a/api/internal/gateway/teacher/v1/handler/teacher_test.go
+++ b/api/internal/gateway/teacher/v1/handler/teacher_test.go
@@ -44,7 +44,7 @@ func TestCreateTeacher(t *testing.T) {
 						LastNameKana:  "なかむら",
 						FirstNameKana: "こうだい",
 						Mail:          "teacher-test001@calmato.jp",
-						Role:          entity.Role(entity.RoleTeacher),
+						Role:          entity.RoleTeacher,
 						CreatedAt:     now.String(),
 						UpdatedAt:     now.String(),
 					},

--- a/api/internal/gateway/teacher/v1/response/auth.go
+++ b/api/internal/gateway/teacher/v1/response/auth.go
@@ -1,0 +1,7 @@
+package response
+
+import "github.com/calmato/shs-web/api/internal/gateway/teacher/v1/entity"
+
+type AuthResponse struct {
+	*entity.Auth
+}

--- a/api/internal/gateway/util/metadata.go
+++ b/api/internal/gateway/util/metadata.go
@@ -2,12 +2,26 @@ package util
 
 import (
 	"context"
+	"errors"
+	"strings"
 
 	"github.com/calmato/shs-web/api/pkg/metadata"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	gmd "google.golang.org/grpc/metadata"
 )
+
+var errNotExistsAuthorizationHeader = errors.New("util: authorization header is not contain")
+
+func GetAuthToken(c *gin.Context) (string, error) {
+	authorization := c.GetHeader("Authorization")
+	if authorization == "" {
+		return "", errNotExistsAuthorizationHeader
+	}
+
+	token := strings.Replace(authorization, "Bearer ", "", 1)
+	return token, nil
+}
 
 func SetMetadata(c *gin.Context) context.Context {
 	ctx := metadata.GinContextToContext(c)

--- a/api/internal/gateway/util/metadata_test.go
+++ b/api/internal/gateway/util/metadata_test.go
@@ -11,6 +11,51 @@ import (
 	gmd "google.golang.org/grpc/metadata"
 )
 
+func TestGetAuthToken(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		ctx    *gin.Context
+		expect string
+		isErr  bool
+	}{
+		{
+			name: "success",
+			ctx: func() *gin.Context {
+				gin.SetMode(gin.TestMode)
+				w := httptest.NewRecorder()
+				c, _ := gin.CreateTestContext(w)
+				c.Request = &http.Request{Header: http.Header{}}
+				c.Request.Header.Set("Authorization", "Bearer xxxxxx")
+				return c
+			}(),
+			expect: "xxxxxx",
+			isErr:  false,
+		},
+		{
+			name: "not exists authorization header",
+			ctx: func() *gin.Context {
+				gin.SetMode(gin.TestMode)
+				w := httptest.NewRecorder()
+				c, _ := gin.CreateTestContext(w)
+				c.Request = &http.Request{Header: http.Header{}}
+				return c
+			}(),
+			expect: "",
+			isErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := GetAuthToken(tt.ctx)
+			assert.Equal(t, tt.isErr, err != nil, err)
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}
+
 func TestSetMetadata(t *testing.T) {
 	t.Parallel()
 	gin.SetMode(gin.TestMode)


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
講師認証情報取得APIのモック作成

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->
* https://github.com/calmato/shs-web/pull/18 のマージ後に詳細実装

## 備考

<!-- マージ後に必要な操作などがあればここに -->
