### PR TITLE
feat: スマホレイアウトにした際に右側に余白ができる問題への対応

### DIFF
--- a/web/teacher/src/layouts/default.vue
+++ b/web/teacher/src/layouts/default.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app :style="{ background }">
+  <v-app class="root" :style="{ background }">
     <the-header :overlay="overlay" @click="handleClickMenu" />
     <v-main>
       <nuxt />
@@ -100,3 +100,9 @@ export default defineComponent({
   },
 })
 </script>
+
+<style lang="css" scoped>
+.root {
+  overflow: hidden;
+}
+</style>


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->

- スマホレイアウトにした際に右側に余白ができる問題への対応

### レビュー時のポイント

多分あんまり良い対応策ではない…
どうやってもHeader要素が可変になってしまったので泣く泣くこうした

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
