### PR TITLE
feat(web/teacher): implement list teacher api client

### DIFF
--- a/web/teacher/src/components/organisms/TheStudentList.vue
+++ b/web/teacher/src/components/organisms/TheStudentList.vue
@@ -35,11 +35,11 @@ export default defineComponent({
 
     const getSchoolType = (typ: SchoolType): string => {
       switch (typ) {
-        case SchoolType.ElementarySchool:
+        case SchoolType.ELEMENTARY_SCHOOL:
           return '小学校'
-        case SchoolType.JuniorHighSchool:
+        case SchoolType.JUNIOR_HIGH_SCHOOL:
           return '中学校'
-        case SchoolType.HighSchool:
+        case SchoolType.HIGH_SCHOOL:
           return '高等学校'
         default:
           return ''
@@ -48,11 +48,11 @@ export default defineComponent({
 
     const getSchoolTypeColor = (typ: SchoolType): string => {
       switch (typ) {
-        case SchoolType.ElementarySchool:
+        case SchoolType.ELEMENTARY_SCHOOL:
           return 'primary'
-        case SchoolType.JuniorHighSchool:
+        case SchoolType.JUNIOR_HIGH_SCHOOL:
           return 'secondary'
-        case SchoolType.HighSchool:
+        case SchoolType.HIGH_SCHOOL:
           return 'info'
         default:
           return ''

--- a/web/teacher/src/pages/users/index.vue
+++ b/web/teacher/src/pages/users/index.vue
@@ -3,8 +3,9 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, ref, SetupContext } from '@nuxtjs/composition-api'
+import { computed, defineComponent, ref, SetupContext, useAsync } from '@nuxtjs/composition-api'
 import TheUserTop from '~/components/templates/TheUserTop.vue'
+import { CommonStore, UserStore } from '~/store'
 
 export default defineComponent({
   components: {
@@ -18,6 +19,17 @@ export default defineComponent({
 
     const teachers = computed(() => store.getters['user/getTeachers'])
     const students = computed(() => store.getters['user/getStudents'])
+
+    useAsync(async () => {
+      CommonStore.startConnection()
+      await UserStore.listTeachers()
+        .catch((err: Error) => {
+          console.log('feiled to list teachers', err)
+        })
+        .finally(() => {
+          CommonStore.endConnection()
+        })
+    })
 
     return {
       loading,

--- a/web/teacher/src/store/user.ts
+++ b/web/teacher/src/store/user.ts
@@ -1,48 +1,13 @@
 import { Module, VuexModule, Mutation, Action } from 'vuex-module-decorators'
+import { AxiosError } from 'axios'
+import { $axios } from '~/plugins/axios'
+import { TeachersResponse, Teacher as TeacherResponse } from '~/types/api/v1'
 import { Student, StudentMap, Teacher, TeacherMap, UserState } from '~/types/store'
+import { ErrorResponse } from '~/types/api/exception'
+import { ApiError } from '~/types/exception'
 
 const initialState: UserState = {
-  teachers: [
-    {
-      id: '000000000000000000001',
-      name: '中村 太郎',
-      nameKana: 'なかむら たろう',
-      lastName: '中村',
-      firstName: '太郎',
-      lastNameKana: 'なかむら',
-      firstNameKana: 'たろう',
-      mail: 'teacher-001@calmato.jp',
-      role: 0,
-      createdAt: '',
-      updatedAt: '',
-    },
-    {
-      id: '000000000000000000002',
-      name: '西山 幸子',
-      nameKana: 'にしやま さちこ',
-      lastName: '西山',
-      firstName: '幸子',
-      lastNameKana: 'にしやま',
-      firstNameKana: 'さちこ',
-      mail: 'teacher-002@calmato.jp',
-      role: 0,
-      createdAt: '',
-      updatedAt: '',
-    },
-    {
-      id: '000000000000000000003',
-      name: '鈴木 小太郎',
-      nameKana: 'すずき こたろう',
-      lastName: '鈴木',
-      firstName: '小太郎',
-      lastNameKana: 'すずき',
-      firstNameKana: 'こたろう',
-      mail: 'teacher-003@calmato.jp',
-      role: 1,
-      createdAt: '',
-      updatedAt: '',
-    },
-  ],
+  teachers: [],
   students: [
     {
       id: '123456789012345678901',
@@ -116,5 +81,22 @@ export default class UserModule extends VuexModule {
   public factory(): void {
     this.setStudents(initialState.students)
     this.setTeachers(initialState.teachers)
+  }
+
+  @Action({ rawError: true })
+  public async listTeachers(): Promise<void> {
+    // TODO: limit, offset周りの対応
+    await $axios
+      .$get('/v1/teachers')
+      .then((res: TeachersResponse) => {
+        const teachers: Teacher[] = res.teachers.map((data: TeacherResponse): Teacher => {
+          return { ...data }
+        })
+        this.setTeachers(teachers)
+      })
+      .catch((err: AxiosError) => {
+        const res: ErrorResponse = { ...err.response?.data }
+        throw new ApiError(res.status, res.message, res)
+      })
   }
 }

--- a/web/teacher/src/types/api/v1/user.ts
+++ b/web/teacher/src/types/api/v1/user.ts
@@ -1,10 +1,15 @@
-/**
- * Hello - テスト用API (TODO: remove)
- */
-export interface HelloRequest {
-  name: string
+export interface Teacher {
+  id: string
+  lastName: string
+  firstName: string
+  lastNameKana: string
+  firstNameKana: string
+  mail: string
+  role: number
+  createdAt: string
+  updatedAt: string
 }
 
-export interface HelloResponse {
-  message: string
+export interface TeachersResponse {
+  teachers: Teacher[]
 }

--- a/web/teacher/src/types/store/common.ts
+++ b/web/teacher/src/types/store/common.ts
@@ -6,15 +6,17 @@ export enum PromiseState {
 
 // Role 権限
 export enum Role {
-  TEACHER = 0, // 講師
-  ADMINISTRATOR = 1, // 管理者
+  UNKNOWN = 0, // 不明
+  TEACHER = 1, // 講師
+  ADMINISTRATOR = 2, // 管理者
 }
 
 // SchoolType 校種
 export enum SchoolType {
-  ElementarySchool = 0, // 小学校
-  JuniorHighSchool = 1, // 中学校
-  HighSchool = 2, // 高等学校
+  UNKNOWN = 0, // 不明
+  ELEMENTARY_SCHOOL = 1, // 小学校
+  JUNIOR_HIGH_SCHOOL = 2, // 中学校
+  HIGH_SCHOOL = 3, // 高等学校
 }
 
 export interface CommonState {

--- a/web/teacher/test/components/organisms/TheStudentList.test.ts
+++ b/web/teacher/test/components/organisms/TheStudentList.test.ts
@@ -65,37 +65,37 @@ describe('components/organisms/TheStudentList', () => {
     describe('methods', () => {
       describe('getSchoolType', () => {
         it('type is elementary school', () => {
-          expect(wrapper.vm.getSchoolType(SchoolType.ElementarySchool)).toBe('小学校')
+          expect(wrapper.vm.getSchoolType(SchoolType.ELEMENTARY_SCHOOL)).toBe('小学校')
         })
 
         it('type is junior high school', () => {
-          expect(wrapper.vm.getSchoolType(SchoolType.JuniorHighSchool)).toBe('中学校')
+          expect(wrapper.vm.getSchoolType(SchoolType.JUNIOR_HIGH_SCHOOL)).toBe('中学校')
         })
 
         it('type is high school', () => {
-          expect(wrapper.vm.getSchoolType(SchoolType.HighSchool)).toBe('高等学校')
+          expect(wrapper.vm.getSchoolType(SchoolType.HIGH_SCHOOL)).toBe('高等学校')
         })
 
         it('invalid type', () => {
-          expect(wrapper.vm.getSchoolType(-1)).toBe('')
+          expect(wrapper.vm.getSchoolType(SchoolType.UNKNOWN)).toBe('')
         })
       })
 
       describe('getSchoolTypeColor', () => {
         it('type is elementary school', () => {
-          expect(wrapper.vm.getSchoolTypeColor(SchoolType.ElementarySchool)).toBe('primary')
+          expect(wrapper.vm.getSchoolTypeColor(SchoolType.ELEMENTARY_SCHOOL)).toBe('primary')
         })
 
         it('type is junior high school', () => {
-          expect(wrapper.vm.getSchoolTypeColor(SchoolType.JuniorHighSchool)).toBe('secondary')
+          expect(wrapper.vm.getSchoolTypeColor(SchoolType.JUNIOR_HIGH_SCHOOL)).toBe('secondary')
         })
 
         it('type is high school', () => {
-          expect(wrapper.vm.getSchoolTypeColor(SchoolType.HighSchool)).toBe('info')
+          expect(wrapper.vm.getSchoolTypeColor(SchoolType.HIGH_SCHOOL)).toBe('info')
         })
 
         it('invalid type', () => {
-          expect(wrapper.vm.getSchoolTypeColor(-1)).toBe('')
+          expect(wrapper.vm.getSchoolTypeColor(SchoolType.UNKNOWN)).toBe('')
         })
       })
 

--- a/web/teacher/test/helpers/api-mock/index.ts
+++ b/web/teacher/test/helpers/api-mock/index.ts
@@ -1,4 +1,5 @@
 import * as AuthStore from './auth'
+import * as UserStore from './user'
 import { ErrorResponse } from '~/types/api/exception'
 
 const err: { response: { data: ErrorResponse } } = {
@@ -14,6 +15,7 @@ const err: { response: { data: ErrorResponse } } = {
 export default {
   get: {
     ...AuthStore.showAuth,
+    ...UserStore.listTeachers,
   },
   post: {},
   patch: {},

--- a/web/teacher/test/helpers/api-mock/user.ts
+++ b/web/teacher/test/helpers/api-mock/user.ts
@@ -1,7 +1,41 @@
-import { HelloResponse } from '~/types/api/v1'
+import { TeachersResponse } from '~/types/api/v1'
 
-export const hello: { [key: string]: HelloResponse } = {
-  '/v1/hello': {
-    message: 'test message',
+export const listTeachers: { [key: string]: TeachersResponse } = {
+  '/v1/teachers': {
+    teachers: [
+      {
+        id: '000000000000000000001',
+        lastName: '中村',
+        firstName: '太郎',
+        lastNameKana: 'なかむら',
+        firstNameKana: 'たろう',
+        mail: 'teacher-001@calmato.jp',
+        role: 1,
+        createdAt: '2021-12-02T18:30:00+09:00',
+        updatedAt: '2021-12-02T18:30:00+09:00',
+      },
+      {
+        id: '000000000000000000002',
+        lastName: '西山',
+        firstName: '幸子',
+        lastNameKana: 'にしやま',
+        firstNameKana: 'さちこ',
+        mail: 'teacher-002@calmato.jp',
+        role: 1,
+        createdAt: '2021-12-02T18:30:00+09:00',
+        updatedAt: '2021-12-02T18:30:00+09:00',
+      },
+      {
+        id: '000000000000000000003',
+        lastName: '鈴木',
+        firstName: '小太郎',
+        lastNameKana: 'すずき',
+        firstNameKana: 'こたろう',
+        mail: 'teacher-003@calmato.jp',
+        role: 2,
+        createdAt: '2021-12-02T18:30:00+09:00',
+        updatedAt: '2021-12-02T18:30:00+09:00',
+      },
+    ],
   },
 }

--- a/web/teacher/test/store/user.test.ts
+++ b/web/teacher/test/store/user.test.ts
@@ -1,5 +1,7 @@
-import { setup, refresh } from '~~/test/helpers/store-helper'
+import { setup, refresh, setSafetyMode } from '~~/test/helpers/store-helper'
 import { UserStore } from '~/store'
+import { ApiError } from '~/types/exception'
+import { ErrorResponse } from '~/types/api/exception'
 
 describe('store/user', () => {
   beforeEach(() => {
@@ -50,90 +52,80 @@ describe('store/user', () => {
     })
 
     it('getTeachers', () => {
-      expect(UserStore.getTeachers).toEqual([
-        {
-          id: '000000000000000000001',
-          name: '中村 太郎',
-          nameKana: 'なかむら たろう',
-          lastName: '中村',
-          firstName: '太郎',
-          lastNameKana: 'なかむら',
-          firstNameKana: 'たろう',
-          mail: 'teacher-001@calmato.jp',
-          role: 0,
-          createdAt: '',
-          updatedAt: '',
-        },
-        {
-          id: '000000000000000000002',
-          name: '西山 幸子',
-          nameKana: 'にしやま さちこ',
-          lastName: '西山',
-          firstName: '幸子',
-          lastNameKana: 'にしやま',
-          firstNameKana: 'さちこ',
-          mail: 'teacher-002@calmato.jp',
-          role: 0,
-          createdAt: '',
-          updatedAt: '',
-        },
-        {
-          id: '000000000000000000003',
-          name: '鈴木 小太郎',
-          nameKana: 'すずき こたろう',
-          lastName: '鈴木',
-          firstName: '小太郎',
-          lastNameKana: 'すずき',
-          firstNameKana: 'こたろう',
-          mail: 'teacher-003@calmato.jp',
-          role: 1,
-          createdAt: '',
-          updatedAt: '',
-        },
-      ])
+      expect(UserStore.getTeachers).toEqual([])
     })
 
     it('getTeacherMap', () => {
-      expect(UserStore.getTeacherMap).toEqual({
-        '000000000000000000001': {
-          id: '000000000000000000001',
-          name: '中村 太郎',
-          nameKana: 'なかむら たろう',
-          lastName: '中村',
-          firstName: '太郎',
-          lastNameKana: 'なかむら',
-          firstNameKana: 'たろう',
-          mail: 'teacher-001@calmato.jp',
-          role: 0,
-          createdAt: '',
-          updatedAt: '',
-        },
-        '000000000000000000002': {
-          id: '000000000000000000002',
-          name: '西山 幸子',
-          nameKana: 'にしやま さちこ',
-          lastName: '西山',
-          firstName: '幸子',
-          lastNameKana: 'にしやま',
-          firstNameKana: 'さちこ',
-          mail: 'teacher-002@calmato.jp',
-          role: 0,
-          createdAt: '',
-          updatedAt: '',
-        },
-        '000000000000000000003': {
-          id: '000000000000000000003',
-          name: '鈴木 小太郎',
-          nameKana: 'すずき こたろう',
-          lastName: '鈴木',
-          firstName: '小太郎',
-          lastNameKana: 'すずき',
-          firstNameKana: 'こたろう',
-          mail: 'teacher-003@calmato.jp',
-          role: 1,
-          createdAt: '',
-          updatedAt: '',
-        },
+      expect(UserStore.getTeacherMap).toEqual({})
+    })
+  })
+
+  describe('actions', () => {
+    describe('listTeachers', () => {
+      describe('success', () => {
+        beforeEach(() => {
+          setSafetyMode(true)
+        })
+
+        it('stateが更新されていること', async () => {
+          await UserStore.listTeachers()
+          expect(UserStore.getTeachers).toEqual([
+            {
+              id: '000000000000000000001',
+              name: '中村 太郎',
+              nameKana: 'なかむら たろう',
+              lastName: '中村',
+              firstName: '太郎',
+              lastNameKana: 'なかむら',
+              firstNameKana: 'たろう',
+              mail: 'teacher-001@calmato.jp',
+              role: 1,
+              createdAt: '2021-12-02T18:30:00+09:00',
+              updatedAt: '2021-12-02T18:30:00+09:00',
+            },
+            {
+              id: '000000000000000000002',
+              name: '西山 幸子',
+              nameKana: 'にしやま さちこ',
+              lastName: '西山',
+              firstName: '幸子',
+              lastNameKana: 'にしやま',
+              firstNameKana: 'さちこ',
+              mail: 'teacher-002@calmato.jp',
+              role: 1,
+              createdAt: '2021-12-02T18:30:00+09:00',
+              updatedAt: '2021-12-02T18:30:00+09:00',
+            },
+            {
+              id: '000000000000000000003',
+              name: '鈴木 小太郎',
+              nameKana: 'すずき こたろう',
+              lastName: '鈴木',
+              firstName: '小太郎',
+              lastNameKana: 'すずき',
+              firstNameKana: 'こたろう',
+              mail: 'teacher-003@calmato.jp',
+              role: 2,
+              createdAt: '2021-12-02T18:30:00+09:00',
+              updatedAt: '2021-12-02T18:30:00+09:00',
+            },
+          ])
+        })
+      })
+
+      describe('failure', () => {
+        beforeEach(() => {
+          setSafetyMode(false)
+        })
+
+        it('rejectが返されること', async () => {
+          const err = new ApiError(400, 'api error', {
+            status: 400,
+            message: 'api error',
+            details: 'some error',
+          } as ErrorResponse)
+          await expect(UserStore.listTeachers()).rejects.toThrow(err)
+        })
       })
     })
   })


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
講師一覧APIから取得した情報をテーブルに表示できるように設定

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->
* UIの調整
* Limit, Offset指定で一覧情報を取得できるように
* 検索フォームの追加対応

## 備考

<!-- マージ後に必要な操作などがあればここに -->
