### PR TITLE
feat(user-api): add total field in list teachers response

### DIFF
--- a/api/internal/gateway/teacher/v1/handler/teacher.go
+++ b/api/internal/gateway/teacher/v1/handler/teacher.go
@@ -45,6 +45,7 @@ func (h *apiV1Handler) ListTeachers(ctx *gin.Context) {
 
 	res := &response.TeachersResponse{
 		Teachers: entity.NewTeachers(teachers),
+		Total:    out.Total,
 	}
 	ctx.JSON(http.StatusOK, res)
 }

--- a/api/internal/gateway/teacher/v1/handler/teacher_test.go
+++ b/api/internal/gateway/teacher/v1/handler/teacher_test.go
@@ -40,7 +40,7 @@ func TestListTeachers(t *testing.T) {
 			name: "success",
 			setup: func(ctx context.Context, t *testing.T, mocks *mocks, ctrl *gomock.Controller) {
 				in := &user.ListTeachersRequest{Limit: 100, Offset: 20}
-				out := &user.ListTeachersResponse{Teachers: teachers}
+				out := &user.ListTeachersResponse{Teachers: teachers, Total: 1}
 				mocks.user.EXPECT().ListTeachers(gomock.Any(), in).Return(out, nil)
 			},
 			query: "?limit=100&offset=20",
@@ -60,6 +60,7 @@ func TestListTeachers(t *testing.T) {
 							UpdatedAt:     now,
 						},
 					},
+					Total: 1,
 				},
 			},
 		},

--- a/api/internal/gateway/teacher/v1/response/teacher.go
+++ b/api/internal/gateway/teacher/v1/response/teacher.go
@@ -8,4 +8,5 @@ type TeacherResponse struct {
 
 type TeachersResponse struct {
 	Teachers entity.Teachers `json:"teachers"` // 講師一覧
+	Total    int64           `json:"total"`    // 講師合計数
 }

--- a/api/internal/user/api/teacher.go
+++ b/api/internal/user/api/teacher.go
@@ -2,33 +2,63 @@ package api
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/calmato/shs-web/api/internal/user/database"
 	"github.com/calmato/shs-web/api/internal/user/entity"
 	"github.com/calmato/shs-web/api/pkg/uuid"
 	"github.com/calmato/shs-web/api/proto/user"
+	"golang.org/x/sync/errgroup"
 )
 
 func (s *userService) ListTeachers(
 	ctx context.Context, req *user.ListTeachersRequest,
 ) (*user.ListTeachersResponse, error) {
+	const prefixKey = "listTeachers"
 	if err := s.validator.ListTeachers(req); err != nil {
 		return nil, gRPCError(err)
 	}
 
-	params := &database.ListTeachersParams{
-		Limit:  int(req.Limit),
-		Offset: int(req.Offset),
-	}
-	teachers, err := s.db.Teacher.List(ctx, params)
+	sharedKey := fmt.Sprintf("%s:%d:%d", prefixKey, req.Limit, req.Offset)
+	res, err, _ := s.sharedGroup.Do(sharedKey, func() (interface{}, error) {
+		teachers, total, err := s.listTeachers(ctx, req.Limit, req.Offset)
+		if err != nil {
+			return nil, err
+		}
+		res := &user.ListTeachersResponse{
+			Teachers: teachers.Proto(),
+			Total:    total,
+		}
+		return res, nil
+	})
 	if err != nil {
 		return nil, gRPCError(err)
 	}
 
-	res := &user.ListTeachersResponse{
-		Teachers: teachers.Proto(),
+	return res.(*user.ListTeachersResponse), nil
+}
+
+func (s *userService) listTeachers(ctx context.Context, limit, offset int64) (entity.Teachers, int64, error) {
+	eg, ectx := errgroup.WithContext(ctx)
+	var teachers entity.Teachers
+	eg.Go(func() (err error) {
+		params := &database.ListTeachersParams{
+			Limit:  int(limit),
+			Offset: int(offset),
+		}
+		teachers, err = s.db.Teacher.List(ectx, params)
+		return
+	})
+	var total int64
+	eg.Go(func() (err error) {
+		total, err = s.db.Teacher.Count(ectx)
+		return
+	})
+	if err := eg.Wait(); err != nil {
+		return nil, 0, err
 	}
-	return res, nil
+
+	return teachers, total, nil
 }
 
 func (s *userService) GetTeacher(ctx context.Context, req *user.GetTeacherRequest) (*user.GetTeacherResponse, error) {

--- a/api/internal/user/api/teacher_test.go
+++ b/api/internal/user/api/teacher_test.go
@@ -50,7 +50,8 @@ func TestListTeachers(t *testing.T) {
 			name: "success",
 			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
 				mocks.validator.EXPECT().ListTeachers(req).Return(nil)
-				mocks.db.Teacher.EXPECT().List(ctx, params).Return(teachers, nil)
+				mocks.db.Teacher.EXPECT().List(gomock.Any(), params).Return(teachers, nil)
+				mocks.db.Teacher.EXPECT().Count(gomock.Any()).Return(int64(1), nil)
 			},
 			req: req,
 			expect: &testResponse{
@@ -69,6 +70,7 @@ func TestListTeachers(t *testing.T) {
 							UpdatedAt:     now.Unix(),
 						},
 					},
+					Total: 1,
 				},
 			},
 		},
@@ -87,7 +89,20 @@ func TestListTeachers(t *testing.T) {
 			name: "failed to list teacher",
 			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
 				mocks.validator.EXPECT().ListTeachers(req).Return(nil)
-				mocks.db.Teacher.EXPECT().List(ctx, params).Return(nil, errmock)
+				mocks.db.Teacher.EXPECT().List(gomock.Any(), params).Return(nil, errmock)
+				mocks.db.Teacher.EXPECT().Count(gomock.Any()).Return(int64(3), nil)
+			},
+			req: req,
+			expect: &testResponse{
+				code: codes.Internal,
+			},
+		},
+		{
+			name: "failed to count",
+			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
+				mocks.validator.EXPECT().ListTeachers(req).Return(nil)
+				mocks.db.Teacher.EXPECT().List(gomock.Any(), params).Return(teachers, nil)
+				mocks.db.Teacher.EXPECT().Count(gomock.Any()).Return(int64(0), errmock)
 			},
 			req: req,
 			expect: &testResponse{

--- a/api/internal/user/database/database.go
+++ b/api/internal/user/database/database.go
@@ -41,6 +41,7 @@ type Teacher interface {
 	List(ctx context.Context, p *ListTeachersParams, fields ...string) (entity.Teachers, error)
 	Get(ctx context.Context, id string, fields ...string) (*entity.Teacher, error)
 	Create(ctx context.Context, t *entity.Teacher) error
+	Count(ctx context.Context) (int64, error)
 }
 
 type ListTeachersParams struct {

--- a/api/internal/user/database/teacher.go
+++ b/api/internal/user/database/teacher.go
@@ -87,3 +87,9 @@ func (t *teacher) Create(ctx context.Context, teacher *entity.Teacher) error {
 	}
 	return dbError(tx.Commit().Error)
 }
+
+func (t *teacher) Count(ctx context.Context) (int64, error) {
+	var total int64
+	err := t.db.DB.Table(teacherTable).Count(&total).Error
+	return total, dbError(err)
+}

--- a/api/mock/user/database/database.go
+++ b/api/mock/user/database/database.go
@@ -36,6 +36,21 @@ func (m *MockTeacher) EXPECT() *MockTeacherMockRecorder {
 	return m.recorder
 }
 
+// Count mocks base method.
+func (m *MockTeacher) Count(ctx context.Context) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Count", ctx)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Count indicates an expected call of Count.
+func (mr *MockTeacherMockRecorder) Count(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockTeacher)(nil).Count), ctx)
+}
+
 // Create mocks base method.
 func (m *MockTeacher) Create(ctx context.Context, t *entity.Teacher) error {
 	m.ctrl.T.Helper()

--- a/api/proto/user/service.proto
+++ b/api/proto/user/service.proto
@@ -24,6 +24,7 @@ message ListTeachersRequest {
 
 message ListTeachersResponse {
   repeated Teacher teachers = 1;
+  int64            total    = 2;
 }
 
 message GetTeacherRequest {

--- a/docs/swagger/teacher/components/schemas/v1/teachers.response.yaml
+++ b/docs/swagger/teacher/components/schemas/v1/teachers.response.yaml
@@ -76,6 +76,10 @@ teachersResponse:
           updatedAt:
             type: string
             description: 更新日時
+    total:
+      type: integer
+      format: int64
+      description: 講師合計数
   example:
     teachers:
     - id: 'kSByoE6FetnPs5Byk3a9Zx'
@@ -96,3 +100,4 @@ teachersResponse:
       role: 1
       createdAt: '2021-12-12T12:12:30.100Z'
       updatedAt: '2021-12-12T12:12:30.100Z'
+    total: 2


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
講師一覧取得APIのレスポンスへ、DBに保存されているレコードの数を返す用のフィールドを追加しました。

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
