### PR TITLE
feat(web/teacher): add auth response field

### DIFF
--- a/web/teacher/src/store/auth.ts
+++ b/web/teacher/src/store/auth.ts
@@ -7,7 +7,7 @@ import { ErrorResponse } from '~/types/api/exception'
 import { AuthResponse } from '~/types/api/v1'
 import { ApiError } from '~/types/exception'
 import { SignInForm } from '~/types/form'
-import { Auth, AuthState, Role } from '~/types/store'
+import { Auth, AuthState, Role, SchoolType, Subject } from '~/types/store'
 
 const initialState: AuthState = {
   uid: '',
@@ -21,6 +21,7 @@ const initialState: AuthState = {
     firstNameKana: '',
     mail: '',
     role: Role.TEACHER,
+    subjects: new Map<SchoolType, Subject[]>(),
   },
 }
 

--- a/web/teacher/src/store/lesson.ts
+++ b/web/teacher/src/store/lesson.ts
@@ -1,5 +1,5 @@
 import { Module, VuexModule, Mutation, Action } from 'vuex-module-decorators'
-import { Lesson, LessonState, Subject, SubjectMap } from '~/types/store'
+import { Lesson, LessonState, SchoolType, Subject, SubjectMap } from '~/types/store'
 
 const initialState: LessonState = {
   subjects: [
@@ -7,6 +7,7 @@ const initialState: LessonState = {
       id: 1,
       name: '国語',
       color: '#F8BBD0',
+      schoolType: SchoolType.ELEMENTARY_SCHOOL,
       createdAt: '',
       updatedAt: '',
     },
@@ -14,6 +15,7 @@ const initialState: LessonState = {
       id: 2,
       name: '数学',
       color: '#BBDEFB',
+      schoolType: SchoolType.JUNIOR_HIGH_SCHOOL,
       createdAt: '',
       updatedAt: '',
     },
@@ -21,6 +23,7 @@ const initialState: LessonState = {
       id: 3,
       name: '英語',
       color: '#FEE6C9',
+      schoolType: SchoolType.HIGH_SCHOOL,
       createdAt: '',
       updatedAt: '',
     },

--- a/web/teacher/src/types/api/v1/auth.ts
+++ b/web/teacher/src/types/api/v1/auth.ts
@@ -1,3 +1,12 @@
+interface Subject {
+  id: number
+  name: string
+  color: string
+  schoolType: number
+  createdAt: string
+  updatedAt: string
+}
+
 export interface AuthResponse {
   id: string
   lastName: string
@@ -6,4 +15,5 @@ export interface AuthResponse {
   firstNameKana: string
   mail: string
   role: number
+  subjects: Map<number, Subject>
 }

--- a/web/teacher/src/types/api/v1/auth.ts
+++ b/web/teacher/src/types/api/v1/auth.ts
@@ -15,5 +15,5 @@ export interface AuthResponse {
   firstNameKana: string
   mail: string
   role: number
-  subjects: Map<number, Subject>
+  subjects: Map<number, Subject[]>
 }

--- a/web/teacher/src/types/store/auth.ts
+++ b/web/teacher/src/types/store/auth.ts
@@ -1,4 +1,5 @@
-import { Role } from './common'
+import { Subject } from './lesson'
+import { Role, SchoolType } from './common'
 
 export interface Auth {
   id: string
@@ -8,6 +9,7 @@ export interface Auth {
   firstNameKana: string
   mail: string
   role: Role
+  subjects: Map<SchoolType, Subject[]>
 }
 
 export interface AuthState {

--- a/web/teacher/src/types/store/lesson.ts
+++ b/web/teacher/src/types/store/lesson.ts
@@ -1,7 +1,10 @@
+import { SchoolType } from './common'
+
 export interface Subject {
   id: number
   name: string
   color: string
+  schoolType: SchoolType
   createdAt: string
   updatedAt: string
 }

--- a/web/teacher/test/helpers/api-mock/auth.ts
+++ b/web/teacher/test/helpers/api-mock/auth.ts
@@ -1,5 +1,19 @@
 import { AuthResponse } from '~/types/api/v1'
-import { Role } from '~/types/store'
+import { Role, SchoolType } from '~/types/store'
+
+const subjects: AuthResponse['subjects'] = new Map()
+subjects.set(SchoolType.ELEMENTARY_SCHOOL, [])
+subjects.set(SchoolType.JUNIOR_HIGH_SCHOOL, [])
+subjects.set(SchoolType.HIGH_SCHOOL, [
+  {
+    id: 1,
+    name: '国語',
+    color: '#F8BBD0',
+    schoolType: SchoolType.HIGH_SCHOOL,
+    createdAt: '2021-12-02T18:30:00+09:00',
+    updatedAt: '2021-12-02T18:30:00+09:00',
+  },
+])
 
 export const showAuth: { [key: string]: AuthResponse } = {
   '/v1/me': {
@@ -10,5 +24,6 @@ export const showAuth: { [key: string]: AuthResponse } = {
     firstNameKana: 'こうだい',
     mail: 'teacher-test001@calmato.jp',
     role: Role.TEACHER,
+    subjects,
   },
 }

--- a/web/teacher/test/store/auth.test.ts
+++ b/web/teacher/test/store/auth.test.ts
@@ -2,7 +2,21 @@ import { setup, setSafetyMode, refresh } from '~~/test/helpers/store-helper'
 import { AuthStore } from '~/store'
 import { ApiError } from '~/types/exception'
 import { ErrorResponse } from '~/types/api/exception'
-import { Role } from '~/types/store'
+import { Role, SchoolType, Subject } from '~/types/store'
+
+const subjects = new Map<SchoolType, Subject[]>()
+subjects.set(SchoolType.ELEMENTARY_SCHOOL, [])
+subjects.set(SchoolType.JUNIOR_HIGH_SCHOOL, [])
+subjects.set(SchoolType.HIGH_SCHOOL, [
+  {
+    id: 1,
+    name: '国語',
+    color: '#F8BBD0',
+    schoolType: SchoolType.HIGH_SCHOOL,
+    createdAt: '2021-12-02T18:30:00+09:00',
+    updatedAt: '2021-12-02T18:30:00+09:00',
+  },
+])
 
 describe('store/auth', () => {
   beforeEach(() => {
@@ -35,6 +49,7 @@ describe('store/auth', () => {
         firstNameKana: '',
         mail: '',
         role: Role.TEACHER,
+        subjects: new Map<SchoolType, Subject[]>(),
       })
     })
   })
@@ -56,6 +71,7 @@ describe('store/auth', () => {
             firstNameKana: 'こうだい',
             mail: 'teacher-test001@calmato.jp',
             role: Role.TEACHER,
+            subjects,
           })
         })
       })

--- a/web/teacher/test/store/lesson.test.ts
+++ b/web/teacher/test/store/lesson.test.ts
@@ -1,5 +1,6 @@
 import { setup, refresh } from '~~/test/helpers/store-helper'
 import { LessonStore } from '~/store'
+import { SchoolType } from '~/types/store'
 
 describe('store/lesson', () => {
   beforeEach(() => {
@@ -17,6 +18,7 @@ describe('store/lesson', () => {
           id: 1,
           name: '国語',
           color: '#F8BBD0',
+          schoolType: SchoolType.ELEMENTARY_SCHOOL,
           createdAt: '',
           updatedAt: '',
         },
@@ -24,6 +26,7 @@ describe('store/lesson', () => {
           id: 2,
           name: '数学',
           color: '#BBDEFB',
+          schoolType: SchoolType.JUNIOR_HIGH_SCHOOL,
           createdAt: '',
           updatedAt: '',
         },
@@ -31,6 +34,7 @@ describe('store/lesson', () => {
           id: 3,
           name: '英語',
           color: '#FEE6C9',
+          schoolType: SchoolType.HIGH_SCHOOL,
           createdAt: '',
           updatedAt: '',
         },
@@ -43,6 +47,7 @@ describe('store/lesson', () => {
           id: 1,
           name: '国語',
           color: '#F8BBD0',
+          schoolType: SchoolType.ELEMENTARY_SCHOOL,
           createdAt: '',
           updatedAt: '',
         },
@@ -50,6 +55,7 @@ describe('store/lesson', () => {
           id: 2,
           name: '数学',
           color: '#BBDEFB',
+          schoolType: SchoolType.JUNIOR_HIGH_SCHOOL,
           createdAt: '',
           updatedAt: '',
         },
@@ -57,6 +63,7 @@ describe('store/lesson', () => {
           id: 3,
           name: '英語',
           color: '#FEE6C9',
+          schoolType: SchoolType.HIGH_SCHOOL,
           createdAt: '',
           updatedAt: '',
         },


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
ログインユーザー情報取得APIから受け取るレスポンスのフィールド定義を追加

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
