### PR TITLE
feat(gateway): implement update email and password api

### DIFF
--- a/api/internal/gateway/teacher/v1/handler/api.go
+++ b/api/internal/gateway/teacher/v1/handler/api.go
@@ -67,6 +67,8 @@ func NewAPIV1Handler(params *Params) APIV1Handler {
 func (h *apiV1Handler) AuthRoutes(rg *gin.RouterGroup) {
 	rg.GET("/v1/me", h.GetAuth)
 	rg.PATCH("/v1/me/subjects", h.UpdateMySubjects)
+	rg.PATCH("/v1/me/mail", h.UpdateMyMail)
+	rg.PATCH("/v1/me/password", h.UpdateMyPassword)
 	rg.GET("/v1/teachers", h.ListTeachers)
 	rg.GET("/v1/teachers/:teacherId", h.GetTeacher)
 	rg.GET("/v1/subjects", h.ListSubjects)

--- a/api/internal/gateway/teacher/v1/handler/auth.go
+++ b/api/internal/gateway/teacher/v1/handler/auth.go
@@ -9,6 +9,7 @@ import (
 	"github.com/calmato/shs-web/api/internal/gateway/teacher/v1/response"
 	"github.com/calmato/shs-web/api/internal/gateway/util"
 	"github.com/calmato/shs-web/api/proto/classroom"
+	"github.com/calmato/shs-web/api/proto/user"
 	"github.com/gin-gonic/gin"
 	"golang.org/x/sync/errgroup"
 )
@@ -63,6 +64,55 @@ func (h *apiV1Handler) UpdateMySubjects(ctx *gin.Context) {
 		SchoolType: schoolType,
 	}
 	_, err = h.classroom.UpdateTeacherSubject(c, in)
+	if err != nil {
+		httpError(ctx, err)
+		return
+	}
+
+	ctx.JSON(http.StatusNoContent, gin.H{})
+}
+
+func (h *apiV1Handler) UpdateMyMail(ctx *gin.Context) {
+	c := util.SetMetadata(ctx)
+
+	teacherID := getTeacherID(ctx)
+
+	req := &request.UpdateMyMailRequest{}
+	if err := ctx.BindJSON(req); err != nil {
+		badRequest(ctx, err)
+		return
+	}
+
+	in := &user.UpdateTeacherMailRequest{
+		Id:   teacherID,
+		Mail: req.Mail,
+	}
+	_, err := h.user.UpdateTeacherMail(c, in)
+	if err != nil {
+		httpError(ctx, err)
+		return
+	}
+
+	ctx.JSON(http.StatusNoContent, gin.H{})
+}
+
+func (h *apiV1Handler) UpdateMyPassword(ctx *gin.Context) {
+	c := util.SetMetadata(ctx)
+
+	teacherID := getTeacherID(ctx)
+
+	req := &request.UpdateMyPasswordRequest{}
+	if err := ctx.BindJSON(req); err != nil {
+		badRequest(ctx, err)
+		return
+	}
+
+	in := &user.UpdateTeacherPasswordRequest{
+		Id:                   teacherID,
+		Password:             req.Password,
+		PasswordConfirmation: req.PasswordConfirmation,
+	}
+	_, err := h.user.UpdateTeacherPassword(c, in)
 	if err != nil {
 		httpError(ctx, err)
 		return

--- a/api/internal/gateway/teacher/v1/handler/auth_test.go
+++ b/api/internal/gateway/teacher/v1/handler/auth_test.go
@@ -193,3 +193,115 @@ func TestUpdateMySubjects(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateMyMail(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		setup  func(ctx context.Context, t *testing.T, mocks *mocks, ctrl *gomock.Controller)
+		req    *request.UpdateMyMailRequest
+		expect *testResponse
+	}{
+		{
+			name: "success",
+			setup: func(ctx context.Context, t *testing.T, mocks *mocks, ctrl *gomock.Controller) {
+				in := &user.UpdateTeacherMailRequest{
+					Id:   idmock,
+					Mail: "teacher-test01@calmato.jp",
+				}
+				out := &user.UpdateTeacherMailResponse{}
+				mocks.user.EXPECT().UpdateTeacherMail(gomock.Any(), in).Return(out, nil)
+			},
+			req: &request.UpdateMyMailRequest{
+				Mail: "teacher-test01@calmato.jp",
+			},
+			expect: &testResponse{
+				code: http.StatusNoContent,
+			},
+		},
+		{
+			name: "failed to update teacher mail",
+			setup: func(ctx context.Context, t *testing.T, mocks *mocks, ctrl *gomock.Controller) {
+				in := &user.UpdateTeacherMailRequest{
+					Id:   idmock,
+					Mail: "teacher-test01@calmato.jp",
+				}
+				mocks.user.EXPECT().UpdateTeacherMail(gomock.Any(), in).Return(nil, errmock)
+			},
+			req: &request.UpdateMyMailRequest{
+				Mail: "teacher-test01@calmato.jp",
+			},
+			expect: &testResponse{
+				code: http.StatusInternalServerError,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			const path = "/v1/me/mail"
+			req := newHTTPRequest(t, http.MethodPatch, path, tt.req)
+			testHTTP(t, tt.setup, tt.expect, req)
+		})
+	}
+}
+
+func TestUpdateMyPassword(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		setup  func(ctx context.Context, t *testing.T, mocks *mocks, ctrl *gomock.Controller)
+		req    *request.UpdateMyPasswordRequest
+		expect *testResponse
+	}{
+		{
+			name: "success",
+			setup: func(ctx context.Context, t *testing.T, mocks *mocks, ctrl *gomock.Controller) {
+				in := &user.UpdateTeacherPasswordRequest{
+					Id:                   idmock,
+					Password:             "12345678",
+					PasswordConfirmation: "12345678",
+				}
+				out := &user.UpdateTeacherPasswordResponse{}
+				mocks.user.EXPECT().UpdateTeacherPassword(gomock.Any(), in).Return(out, nil)
+			},
+			req: &request.UpdateMyPasswordRequest{
+				Password:             "12345678",
+				PasswordConfirmation: "12345678",
+			},
+			expect: &testResponse{
+				code: http.StatusNoContent,
+			},
+		},
+		{
+			name: "failed to update teacher password",
+			setup: func(ctx context.Context, t *testing.T, mocks *mocks, ctrl *gomock.Controller) {
+				in := &user.UpdateTeacherPasswordRequest{
+					Id:                   idmock,
+					Password:             "12345678",
+					PasswordConfirmation: "12345678",
+				}
+				mocks.user.EXPECT().UpdateTeacherPassword(gomock.Any(), in).Return(nil, errmock)
+			},
+			req: &request.UpdateMyPasswordRequest{
+				Password:             "12345678",
+				PasswordConfirmation: "12345678",
+			},
+			expect: &testResponse{
+				code: http.StatusInternalServerError,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			const path = "/v1/me/password"
+			req := newHTTPRequest(t, http.MethodPatch, path, tt.req)
+			testHTTP(t, tt.setup, tt.expect, req)
+		})
+	}
+}

--- a/api/internal/gateway/teacher/v1/request/auth.go
+++ b/api/internal/gateway/teacher/v1/request/auth.go
@@ -4,3 +4,12 @@ type UpdateMySubjectRequest struct {
 	SchoolType int32   `json:"schoolType,omitempty"`
 	SubjectIDs []int64 `json:"subjectIds,omitempty"`
 }
+
+type UpdateMyMailRequest struct {
+	Mail string `json:"mail,omitempty"`
+}
+
+type UpdateMyPasswordRequest struct {
+	Password             string `json:"password,omitempty"`
+	PasswordConfirmation string `json:"passwordConfirmation,omitempty"`
+}

--- a/docs/swagger/teacher/components/schemas/v1/auth.request.yaml
+++ b/docs/swagger/teacher/components/schemas/v1/auth.request.yaml
@@ -12,6 +12,11 @@ updateMySubjectsRequest:
         type: integer
         format: int64
         description: 授業科目ID
+  example:
+    schoolType: 1
+    subjectIds:
+    - 1
+    - 2
 updateMyMailRequest:
   type: object
   properties:

--- a/docs/swagger/teacher/components/schemas/v1/auth.request.yaml
+++ b/docs/swagger/teacher/components/schemas/v1/auth.request.yaml
@@ -12,4 +12,23 @@ updateMySubjectsRequest:
         type: integer
         format: int64
         description: 授業科目ID
-
+updateMyMailRequest:
+  type: object
+  properties:
+    mail:
+      type: string
+      description: メールアドレス
+  example:
+    mail: 'teacher-test01@calmato.jp'
+updateMyPasswordRequest:
+  type: object
+  properties:
+    password:
+      type: string
+      description: パスワード
+    passwordConfirmation:
+      type: string
+      description: パスワード
+  example:
+    password: '12345678'
+    passwordConfirmation: '12345678'

--- a/docs/swagger/teacher/openapi.yaml
+++ b/docs/swagger/teacher/openapi.yaml
@@ -19,6 +19,10 @@ paths:
     $ref: './paths/v1/me/index.yaml'
   /v1/me/subjects:
     $ref: './paths/v1/me/subjects.yaml'
+  /v1/me/mail:
+    $ref: './paths/v1/me/mail.yaml'
+  /v1/me/password:
+    $ref: './paths/v1/me/password.yaml'
   # Teachers
   /v1/teachers:
     $ref: './paths/v1/teachers/index.yaml'
@@ -39,6 +43,10 @@ components:
     # Request
     v1UpdateMySubjectsRequest:
       $ref: './components/schemas/v1/auth.request.yaml#/updateMySubjectsRequest'
+    v1UpdateMyMailRequest:
+      $ref: './components/schemas/v1/auth.request.yaml#/updateMyMailRequest'
+    v1UpdateMyPasswordRequest:
+      $ref: './components/schemas/v1/auth.request.yaml#/updateMyPasswordRequest'
     v1CreateTeacherRequest:
       $ref: './components/schemas/v1/teachers.request.yaml#/createTeacherRequest'
     # Response

--- a/docs/swagger/teacher/paths/v1/me/mail.yaml
+++ b/docs/swagger/teacher/paths/v1/me/mail.yaml
@@ -1,0 +1,23 @@
+patch:
+  summary: メールアドレスの更新
+  tags:
+  - Auth
+  security:
+  - BearerAuth: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: './../../../openapi.yaml#/components/schemas/v1UpdateMyMailRequest'
+  responses:
+    204:
+      description: A successful response.
+      content:
+        application/json: {}
+    default:
+      description: An unexpected error response.
+      content:
+        application/json:
+          schema:
+            $ref: './../../../openapi.yaml#/components/schemas/errorResponse'

--- a/docs/swagger/teacher/paths/v1/me/password.yaml
+++ b/docs/swagger/teacher/paths/v1/me/password.yaml
@@ -1,0 +1,23 @@
+patch:
+  summary: パスワードの更新
+  tags:
+  - Auth
+  security:
+  - BearerAuth: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: './../../../openapi.yaml#/components/schemas/v1UpdateMyPasswordRequest'
+  responses:
+    204:
+      description: A successful response.
+      content:
+        application/json: {}
+    default:
+      description: An unexpected error response.
+      content:
+        application/json:
+          schema:
+            $ref: './../../../openapi.yaml#/components/schemas/errorResponse'


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
メールアドレスの更新APIとパスワードの更新APIをそれぞれ実装しました

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
