### PR TITLE
feat(lesson-api): implement list shift summaries api

### DIFF
--- a/api/internal/lesson/api/api_test.go
+++ b/api/internal/lesson/api/api_test.go
@@ -33,7 +33,8 @@ type mocks struct {
 }
 
 type dbMocks struct {
-	Shift *mock_database.MockShift
+	ShiftSummary *mock_database.MockShiftSummary
+	Shift        *mock_database.MockShift
 }
 
 type testResponse struct {
@@ -58,7 +59,8 @@ func newMocks(ctrl *gomock.Controller) *mocks {
 
 func newDBMocks(ctrl *gomock.Controller) *dbMocks {
 	return &dbMocks{
-		Shift: mock_database.NewMockShift(ctrl),
+		ShiftSummary: mock_database.NewMockShiftSummary(ctrl),
+		Shift:        mock_database.NewMockShift(ctrl),
 	}
 }
 
@@ -69,7 +71,8 @@ func newLessonService(mocks *mocks, opts *testOptions) *lessonService {
 		sharedGroup: &singleflight.Group{},
 		waitGroup:   &sync.WaitGroup{},
 		db: &database.Database{
-			Shift: mocks.db.Shift,
+			ShiftSummary: mocks.db.ShiftSummary,
+			Shift:        mocks.db.Shift,
 		},
 		validator: mocks.validator,
 		classroom: mocks.classroom,

--- a/api/internal/lesson/api/shift.go
+++ b/api/internal/lesson/api/shift.go
@@ -2,11 +2,68 @@ package api
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/calmato/shs-web/api/internal/lesson/database"
 	"github.com/calmato/shs-web/api/internal/lesson/entity"
 	"github.com/calmato/shs-web/api/proto/classroom"
 	"github.com/calmato/shs-web/api/proto/lesson"
+	"golang.org/x/sync/errgroup"
 )
+
+func (s *lessonService) ListShiftSummaries(
+	ctx context.Context, req *lesson.ListShiftSummariesRequest,
+) (*lesson.ListShiftSummariesResponse, error) {
+	const prefixKey = "listShifts"
+	if err := s.validator.ListShiftSummaries(req); err != nil {
+		return nil, gRPCError(err)
+	}
+
+	sharedKey := fmt.Sprintf("%s:%d:%d:%d", prefixKey, req.Status, req.Limit, req.Offset)
+	res, err, _ := s.sharedGroup.Do(sharedKey, func() (interface{}, error) {
+		status, _ := entity.NewShiftStatus(req.Status)
+		summaries, total, err := s.listShifts(ctx, status, req.Limit, req.Offset)
+		if err != nil {
+			return nil, err
+		}
+		res := &lesson.ListShiftSummariesResponse{
+			Summaries: summaries.Proto(),
+			Total:     total,
+		}
+		return res, nil
+	})
+	if err != nil {
+		return nil, gRPCError(err)
+	}
+
+	return res.(*lesson.ListShiftSummariesResponse), nil
+}
+
+func (s *lessonService) listShifts(
+	ctx context.Context, status entity.ShiftStatus, limit, offset int64,
+) (entity.ShiftSummaries, int64, error) {
+	eg, ectx := errgroup.WithContext(ctx)
+	var summaries entity.ShiftSummaries
+	eg.Go(func() (err error) {
+		params := &database.ListShiftSummariesParams{
+			Status: status,
+			Limit:  int(limit),
+			Offset: int(offset),
+		}
+		summaries, err = s.db.ShiftSummary.List(ectx, params)
+		return
+	})
+	var total int64
+	eg.Go(func() (err error) {
+		total, err = s.db.ShiftSummary.Count(ectx)
+		return
+	})
+	if err := eg.Wait(); err != nil {
+		return nil, 0, err
+	}
+
+	return summaries, total, nil
+}
 
 func (s *lessonService) CreateShifts(
 	ctx context.Context, req *lesson.CreateShiftsRequest,

--- a/api/internal/lesson/api/shift_test.go
+++ b/api/internal/lesson/api/shift_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/calmato/shs-web/api/internal/lesson/database"
 	"github.com/calmato/shs-web/api/internal/lesson/entity"
 	"github.com/calmato/shs-web/api/internal/lesson/validation"
 	"github.com/calmato/shs-web/api/pkg/jst"
@@ -14,6 +15,107 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/proto"
 )
+
+func TestListShiftSummaries(t *testing.T) {
+	t.Parallel()
+	now := jst.Now()
+
+	req := &lesson.ListShiftSummariesRequest{
+		Status: lesson.ShiftStatus_SHIFT_STATUS_ACCEPTING,
+		Limit:  30,
+		Offset: 0,
+	}
+	params := &database.ListShiftSummariesParams{
+		Status: entity.ShiftStatusAccepting,
+		Limit:  30,
+		Offset: 0,
+	}
+	summaries := entity.ShiftSummaries{
+		{
+			ID:        1,
+			Status:    entity.ShiftStatusAccepting,
+			OpenAt:    jst.Date(2022, 1, 1, 0, 0, 0, 0),
+			EndAt:     jst.Date(2022, 1, 15, 0, 0, 0, 0),
+			CreatedAt: now,
+			UpdatedAt: now,
+		},
+	}
+
+	tests := []struct {
+		name   string
+		setup  func(ctx context.Context, t *testing.T, mocks *mocks)
+		req    *lesson.ListShiftSummariesRequest
+		expect *testResponse
+	}{
+		{
+			name: "success",
+			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
+				mocks.validator.EXPECT().ListShiftSummaries(req).Return(nil)
+				mocks.db.ShiftSummary.EXPECT().List(gomock.Any(), params).Return(summaries, nil)
+				mocks.db.ShiftSummary.EXPECT().Count(gomock.Any()).Return(int64(1), nil)
+			},
+			req: req,
+			expect: &testResponse{
+				code: codes.OK,
+				body: &lesson.ListShiftSummariesResponse{
+					Summaries: []*lesson.ShiftSummary{
+						{
+							Id:        1,
+							Status:    lesson.ShiftStatus_SHIFT_STATUS_ACCEPTING,
+							OpenAt:    jst.Date(2022, 1, 1, 0, 0, 0, 0).Unix(),
+							EndAt:     jst.Date(2022, 1, 15, 0, 0, 0, 0).Unix(),
+							CreatedAt: now.Unix(),
+							UpdatedAt: now.Unix(),
+						},
+					},
+					Total: 1,
+				},
+			},
+		},
+		{
+			name: "invalid argument",
+			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
+				req := &lesson.ListShiftSummariesRequest{}
+				mocks.validator.EXPECT().ListShiftSummaries(req).Return(validation.ErrRequestValidation)
+			},
+			req: &lesson.ListShiftSummariesRequest{},
+			expect: &testResponse{
+				code: codes.InvalidArgument,
+			},
+		},
+		{
+			name: "failed to list shift summaries",
+			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
+				mocks.validator.EXPECT().ListShiftSummaries(req).Return(nil)
+				mocks.db.ShiftSummary.EXPECT().List(gomock.Any(), params).Return(nil, errmock)
+				mocks.db.ShiftSummary.EXPECT().Count(gomock.Any()).Return(int64(1), nil)
+			},
+			req: req,
+			expect: &testResponse{
+				code: codes.Internal,
+			},
+		},
+		{
+			name: "failed to count",
+			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
+				mocks.validator.EXPECT().ListShiftSummaries(req).Return(nil)
+				mocks.db.ShiftSummary.EXPECT().List(gomock.Any(), params).Return(summaries, nil)
+				mocks.db.ShiftSummary.EXPECT().Count(gomock.Any()).Return(int64(0), errmock)
+			},
+			req: req,
+			expect: &testResponse{
+				code: codes.Internal,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, testGRPC(tt.setup, tt.expect, func(ctx context.Context, service *lessonService) (proto.Message, error) {
+			return service.ListShiftSummaries(ctx, tt.req)
+		}))
+	}
+}
 
 func TestCreateShifts(t *testing.T) {
 	t.Parallel()

--- a/api/internal/lesson/database/database.go
+++ b/api/internal/lesson/database/database.go
@@ -26,18 +26,25 @@ type Params struct {
 }
 
 type Database struct {
-	Shift Shift
+	ShiftSummary ShiftSummary
+	Shift        Shift
 }
 
 func NewDatabase(params *Params) *Database {
 	return &Database{
-		Shift: NewShift(params.Database),
+		ShiftSummary: NewShiftSummary(params.Database),
+		Shift:        NewShift(params.Database),
 	}
 }
 
 /**
  * interface
  */
+type ShiftSummary interface {
+	List(ctx context.Context, p *ListShiftSummariesParams, fields ...string) (entity.ShiftSummaries, error)
+	Count(ctx context.Context) (int64, error)
+}
+
 type Shift interface {
 	MultipleCreate(ctx context.Context, summary *entity.ShiftSummary, shifts entity.Shifts) error
 }
@@ -45,6 +52,11 @@ type Shift interface {
 /**
  * params
  */
+type ListShiftSummariesParams struct {
+	Limit  int
+	Offset int
+	Status entity.ShiftStatus
+}
 
 /**
  * private methods

--- a/api/internal/lesson/database/shift_summary.go
+++ b/api/internal/lesson/database/shift_summary.go
@@ -1,7 +1,69 @@
 package database
 
+import (
+	"context"
+	"time"
+
+	"github.com/calmato/shs-web/api/internal/lesson/entity"
+	"github.com/calmato/shs-web/api/pkg/database"
+	"github.com/calmato/shs-web/api/pkg/jst"
+)
+
 const shiftSummaryTable = "shift_summaries"
 
-// var shiftSummaryFields = []string{
-// 	"id", "year_month", "open_at", "end_at", "created_at", "updated_at",
-// }
+var shiftSummaryFields = []string{
+	"id", "year_month", "open_at", "end_at", "created_at", "updated_at",
+}
+
+type shiftSummary struct {
+	db  *database.Client
+	now func() time.Time
+}
+
+func NewShiftSummary(db *database.Client) ShiftSummary {
+	return &shiftSummary{
+		db:  db,
+		now: jst.Now,
+	}
+}
+
+func (s *shiftSummary) List(
+	ctx context.Context, params *ListShiftSummariesParams, fields ...string,
+) (entity.ShiftSummaries, error) {
+	now := s.now()
+	var summaries entity.ShiftSummaries
+	if len(fields) == 0 {
+		fields = shiftSummaryFields
+	}
+
+	stmt := s.db.DB.Table(shiftSummaryTable).Select(fields)
+	switch params.Status {
+	case entity.ShiftStatusWaiting:
+		stmt.Where("open_at > ?", now)
+	case entity.ShiftStatusAccepting:
+		now := s.now()
+		stmt.Where("open_at <= ?", now).Where("end_at >= ?", now)
+	case entity.ShiftStatusFinished:
+		stmt.Where("end_at < ?", now)
+	}
+
+	if params.Limit > 0 {
+		stmt.Limit(params.Limit)
+	}
+	if params.Offset > 0 {
+		stmt.Offset(params.Offset)
+	}
+
+	err := stmt.Find(&summaries).Error
+	if err != nil {
+		return nil, dbError(err)
+	}
+	summaries.Fill(now)
+	return summaries, nil
+}
+
+func (s *shiftSummary) Count(ctx context.Context) (int64, error) {
+	var total int64
+	err := s.db.DB.Table(shiftSummaryTable).Count(&total).Error
+	return total, dbError(err)
+}

--- a/api/internal/lesson/entity/shift_summary.go
+++ b/api/internal/lesson/entity/shift_summary.go
@@ -1,12 +1,15 @@
 package entity
 
 import (
+	"errors"
 	"strconv"
 	"time"
 
 	"github.com/calmato/shs-web/api/pkg/jst"
 	"github.com/calmato/shs-web/api/proto/lesson"
 )
+
+var errInvalidShiftStatus = errors.New("entity: invalid shift status")
 
 type ShiftStatus int32
 
@@ -76,6 +79,14 @@ func (s *ShiftSummary) Proto() *lesson.ShiftSummary {
 	}
 }
 
+func (ss ShiftSummaries) Map() map[int64]*ShiftSummary {
+	res := make(map[int64]*ShiftSummary, len(ss))
+	for _, s := range ss {
+		res[s.ID] = s
+	}
+	return res
+}
+
 func (ss ShiftSummaries) Fill(now time.Time) {
 	for i := range ss {
 		ss[i].Fill(now)
@@ -88,4 +99,17 @@ func (ss ShiftSummaries) Proto() []*lesson.ShiftSummary {
 		summaries[i] = ss[i].Proto()
 	}
 	return summaries
+}
+
+func NewShiftStatus(status lesson.ShiftStatus) (ShiftStatus, error) {
+	switch status {
+	case lesson.ShiftStatus_SHIFT_STATUS_WAITING:
+		return ShiftStatusWaiting, nil
+	case lesson.ShiftStatus_SHIFT_STATUS_ACCEPTING:
+		return ShiftStatusAccepting, nil
+	case lesson.ShiftStatus_SHIFT_STATUS_FINISHED:
+		return ShiftStatusFinished, nil
+	default:
+		return ShiftStatusUnknown, errInvalidShiftStatus
+	}
 }

--- a/api/internal/lesson/entity/shift_summary_test.go
+++ b/api/internal/lesson/entity/shift_summary_test.go
@@ -223,6 +223,52 @@ func TestShiftSummary_Proto(t *testing.T) {
 	}
 }
 
+func TestShiftSummaries_Map(t *testing.T) {
+	t.Parallel()
+	now := jst.Date(2021, 12, 02, 18, 30, 0, 0)
+	tests := []struct {
+		name      string
+		now       time.Time
+		summaries ShiftSummaries
+		expect    map[int64]*ShiftSummary
+	}{
+		{
+			name: "success",
+			now:  now,
+			summaries: ShiftSummaries{
+				{
+					ID:        1,
+					YearMonth: 202201,
+					Status:    ShiftStatusAccepting,
+					OpenAt:    jst.Date(2021, 12, 1, 0, 0, 0, 0),
+					EndAt:     jst.Date(2021, 12, 15, 0, 0, 0, 0),
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+			},
+			expect: map[int64]*ShiftSummary{
+				1: {
+					ID:        1,
+					YearMonth: 202201,
+					Status:    ShiftStatusAccepting,
+					OpenAt:    jst.Date(2021, 12, 1, 0, 0, 0, 0),
+					EndAt:     jst.Date(2021, 12, 15, 0, 0, 0, 0),
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.summaries.Map())
+		})
+	}
+}
+
 func TestShiftSummaries_Fill(t *testing.T) {
 	t.Parallel()
 	now := jst.Date(2021, 12, 02, 18, 30, 0, 0)

--- a/api/internal/lesson/validation/shift.go
+++ b/api/internal/lesson/validation/shift.go
@@ -2,6 +2,15 @@ package validation
 
 import "github.com/calmato/shs-web/api/proto/lesson"
 
+func (v *requestValidation) ListShiftSummaries(req *lesson.ListShiftSummariesRequest) error {
+	if err := req.Validate(); err != nil {
+		validate := err.(lesson.ListShiftSummariesRequestValidationError)
+		return validationError(validate.Error())
+	}
+
+	return nil
+}
+
 func (v *requestValidation) CreateShifts(req *lesson.CreateShiftsRequest) error {
 	if err := req.Validate(); err != nil {
 		validate := err.(lesson.CreateShiftsRequestValidationError)

--- a/api/internal/lesson/validation/shift_test.go
+++ b/api/internal/lesson/validation/shift_test.go
@@ -8,6 +8,63 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestListShiftSummaries(t *testing.T) {
+	t.Parallel()
+	validator := NewRequestValidation()
+
+	tests := []struct {
+		name  string
+		req   *lesson.ListShiftSummariesRequest
+		isErr bool
+	}{
+		{
+			name: "success",
+			req: &lesson.ListShiftSummariesRequest{
+				Limit:  30,
+				Offset: 0,
+				Status: lesson.ShiftStatus_SHIFT_STATUS_ACCEPTING,
+			},
+			isErr: false,
+		},
+		{
+			name: "Limit is gte",
+			req: &lesson.ListShiftSummariesRequest{
+				Limit:  -1,
+				Offset: 0,
+				Status: lesson.ShiftStatus_SHIFT_STATUS_ACCEPTING,
+			},
+			isErr: true,
+		},
+		{
+			name: "Offset is gte",
+			req: &lesson.ListShiftSummariesRequest{
+				Limit:  30,
+				Offset: -1,
+				Status: lesson.ShiftStatus_SHIFT_STATUS_ACCEPTING,
+			},
+			isErr: true,
+		},
+		{
+			name: "Status is defined_only",
+			req: &lesson.ListShiftSummariesRequest{
+				Limit:  30,
+				Offset: 0,
+				Status: lesson.ShiftStatus(-1),
+			},
+			isErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validator.ListShiftSummaries(tt.req)
+			assert.Equal(t, tt.isErr, err != nil, err)
+		})
+	}
+}
+
 func TestCreateShifts(t *testing.T) {
 	t.Parallel()
 	validator := NewRequestValidation()

--- a/api/internal/lesson/validation/validator.go
+++ b/api/internal/lesson/validation/validator.go
@@ -12,6 +12,7 @@ import (
 var ErrRequestValidation = errors.New("validation: invalid argument")
 
 type RequestValidation interface {
+	ListShiftSummaries(req *lesson.ListShiftSummariesRequest) error
 	CreateShifts(req *lesson.CreateShiftsRequest) error
 }
 

--- a/api/mock/lesson/database/database.go
+++ b/api/mock/lesson/database/database.go
@@ -8,9 +8,68 @@ import (
 	context "context"
 	reflect "reflect"
 
+	database "github.com/calmato/shs-web/api/internal/lesson/database"
 	entity "github.com/calmato/shs-web/api/internal/lesson/entity"
 	gomock "github.com/golang/mock/gomock"
 )
+
+// MockShiftSummary is a mock of ShiftSummary interface.
+type MockShiftSummary struct {
+	ctrl     *gomock.Controller
+	recorder *MockShiftSummaryMockRecorder
+}
+
+// MockShiftSummaryMockRecorder is the mock recorder for MockShiftSummary.
+type MockShiftSummaryMockRecorder struct {
+	mock *MockShiftSummary
+}
+
+// NewMockShiftSummary creates a new mock instance.
+func NewMockShiftSummary(ctrl *gomock.Controller) *MockShiftSummary {
+	mock := &MockShiftSummary{ctrl: ctrl}
+	mock.recorder = &MockShiftSummaryMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockShiftSummary) EXPECT() *MockShiftSummaryMockRecorder {
+	return m.recorder
+}
+
+// Count mocks base method.
+func (m *MockShiftSummary) Count(ctx context.Context) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Count", ctx)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Count indicates an expected call of Count.
+func (mr *MockShiftSummaryMockRecorder) Count(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockShiftSummary)(nil).Count), ctx)
+}
+
+// List mocks base method.
+func (m *MockShiftSummary) List(ctx context.Context, p *database.ListShiftSummariesParams, fields ...string) (entity.ShiftSummaries, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, p}
+	for _, a := range fields {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "List", varargs...)
+	ret0, _ := ret[0].(entity.ShiftSummaries)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// List indicates an expected call of List.
+func (mr *MockShiftSummaryMockRecorder) List(ctx, p interface{}, fields ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, p}, fields...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockShiftSummary)(nil).List), varargs...)
+}
 
 // MockShift is a mock of Shift interface.
 type MockShift struct {

--- a/api/mock/lesson/validation/validator.go
+++ b/api/mock/lesson/validation/validator.go
@@ -47,3 +47,17 @@ func (mr *MockRequestValidationMockRecorder) CreateShifts(req interface{}) *gomo
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateShifts", reflect.TypeOf((*MockRequestValidation)(nil).CreateShifts), req)
 }
+
+// ListShiftSummaries mocks base method.
+func (m *MockRequestValidation) ListShiftSummaries(req *lesson.ListShiftSummariesRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListShiftSummaries", req)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ListShiftSummaries indicates an expected call of ListShiftSummaries.
+func (mr *MockRequestValidationMockRecorder) ListShiftSummaries(req interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListShiftSummaries", reflect.TypeOf((*MockRequestValidation)(nil).ListShiftSummaries), req)
+}

--- a/api/mock/proto/lesson/service_grpc.pb.go.go
+++ b/api/mock/proto/lesson/service_grpc.pb.go.go
@@ -56,6 +56,26 @@ func (mr *MockLessonServiceClientMockRecorder) CreateShifts(ctx, in interface{},
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateShifts", reflect.TypeOf((*MockLessonServiceClient)(nil).CreateShifts), varargs...)
 }
 
+// ListShiftSummaries mocks base method.
+func (m *MockLessonServiceClient) ListShiftSummaries(ctx context.Context, in *lesson.ListShiftSummariesRequest, opts ...grpc.CallOption) (*lesson.ListShiftSummariesResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListShiftSummaries", varargs...)
+	ret0, _ := ret[0].(*lesson.ListShiftSummariesResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListShiftSummaries indicates an expected call of ListShiftSummaries.
+func (mr *MockLessonServiceClientMockRecorder) ListShiftSummaries(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListShiftSummaries", reflect.TypeOf((*MockLessonServiceClient)(nil).ListShiftSummaries), varargs...)
+}
+
 // MockLessonServiceServer is a mock of LessonServiceServer interface.
 type MockLessonServiceServer struct {
 	ctrl     *gomock.Controller
@@ -92,6 +112,21 @@ func (m *MockLessonServiceServer) CreateShifts(arg0 context.Context, arg1 *lesso
 func (mr *MockLessonServiceServerMockRecorder) CreateShifts(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateShifts", reflect.TypeOf((*MockLessonServiceServer)(nil).CreateShifts), arg0, arg1)
+}
+
+// ListShiftSummaries mocks base method.
+func (m *MockLessonServiceServer) ListShiftSummaries(arg0 context.Context, arg1 *lesson.ListShiftSummariesRequest) (*lesson.ListShiftSummariesResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListShiftSummaries", arg0, arg1)
+	ret0, _ := ret[0].(*lesson.ListShiftSummariesResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListShiftSummaries indicates an expected call of ListShiftSummaries.
+func (mr *MockLessonServiceServerMockRecorder) ListShiftSummaries(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListShiftSummaries", reflect.TypeOf((*MockLessonServiceServer)(nil).ListShiftSummaries), arg0, arg1)
 }
 
 // mustEmbedUnimplementedLessonServiceServer mocks base method.

--- a/api/proto/lesson/service.proto
+++ b/api/proto/lesson/service.proto
@@ -6,11 +6,24 @@ option go_package = "github.com/calmato/shs-web/api/proto/lesson";
 
 import "github.com/envoyproxy/protoc-gen-validate/validate/validate.proto";
 
+import "lesson/common.proto";
 import "lesson/shift.proto";
 import "lesson/shift_summary.proto";
 
 service LessonService {
+  rpc ListShiftSummaries(ListShiftSummariesRequest) returns (ListShiftSummariesResponse);
   rpc CreateShifts(CreateShiftsRequest) returns (CreateShiftsResponse);
+}
+
+message ListShiftSummariesRequest {
+  int64       limit  = 1 [(validate.rules).int64 = { gte: 0 }];
+  int64       offset = 2 [(validate.rules).int64 = { gte: 0 }];
+  ShiftStatus status = 3 [(validate.rules).enum = { defined_only: true }];
+}
+
+message ListShiftSummariesResponse {
+  repeated ShiftSummary summaries = 1;
+  int64                 total     = 2;
 }
 
 message CreateShiftsRequest {


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
シフト募集一覧取得APIの作成

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
