### PR TITLE
fix(infra): update makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ migrate:
 	docker-compose start mysql mysql_test
 	docker-compose exec mysql bash -c "until mysqladmin ping -u root -p12345678 2> /dev/null; do echo 'waiting for ping response..'; sleep 3; done; echo 'mysql is ready!'"
 	docker-compose exec mysql_test bash -c "until mysqladmin ping -u root -p12345678 2> /dev/null; do echo 'waiting for ping response..'; sleep 3; done; echo 'mysql_test is ready!'"
+	$(MAKE) proto
 	docker-compose run --rm executor sh -c "cd ./hack/database-migrate; go run ./main.go -db-host=mysql -db-port=3306"
 	docker-compose run --rm executor sh -c "cd ./hack/database-migrate; go run ./main.go -db-host=mysql_test -db-port=3306"
 	docker-compose run --rm executor sh -c "cd ./hack/database-seeds; go run ./main.go -db-host=mysql -db-port=3306"


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
`make migrate` コマンド実行時、gRPC周りの更新も同時に行うようにMakefileを変更しました。
`make proto` を一番はじめに実行する書き方にしてもよかったんですが、mysqlサービスへのping実行が成功したあとも起動処理が続いてその後の処理が失敗することがあったので、pingコマンド実行後に `make proto` を実行して時間をかせぐようにしています

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
