### PR TITLE
fix(*): add error handling when record already exists at create

### DIFF
--- a/api/internal/classroom/api/api.go
+++ b/api/internal/classroom/api/api.go
@@ -53,6 +53,8 @@ func gRPCError(err error) error {
 		return status.Error(codes.InvalidArgument, err.Error())
 	case errors.Is(err, database.ErrNotFound):
 		return status.Error(codes.NotFound, err.Error())
+	case errors.Is(err, database.ErrAlreadyExists):
+		return status.Error(codes.AlreadyExists, err.Error())
 	case errors.Is(err, database.ErrNotImplemented):
 		return status.Error(codes.Unimplemented, err.Error())
 	default:

--- a/api/internal/classroom/api/api_test.go
+++ b/api/internal/classroom/api/api_test.go
@@ -150,6 +150,11 @@ func TestGRPCError(t *testing.T) {
 			expect: codes.NotFound,
 		},
 		{
+			name:   "already exists",
+			err:    fmt.Errorf("%w: %s", database.ErrAlreadyExists, "test"),
+			expect: codes.AlreadyExists,
+		},
+		{
 			name:   "unimplemented",
 			err:    fmt.Errorf("%w: %s", database.ErrNotImplemented, "test"),
 			expect: codes.Unimplemented,

--- a/api/internal/classroom/database/database.go
+++ b/api/internal/classroom/database/database.go
@@ -18,6 +18,7 @@ import (
 var (
 	ErrInvalidArgument = errors.New("database: invalid argument")
 	ErrNotFound        = errors.New("database: not found")
+	ErrAlreadyExists   = errors.New("database: already exists")
 	ErrNotImplemented  = errors.New("database: not implemented")
 	ErrInternal        = errors.New("database: internal")
 	ErrUnknown         = errors.New("database: unknown")
@@ -90,6 +91,9 @@ func dbError(err error) error {
 	//nolint:gocritic
 	switch err.(type) {
 	case *mysql.MySQLError:
+		if err.(*mysql.MySQLError).Number == 1062 {
+			return fmt.Errorf("%w: %s", ErrAlreadyExists, err)
+		}
 		return fmt.Errorf("%w: %s", ErrUnknown, err)
 	}
 

--- a/api/internal/classroom/database/database.go
+++ b/api/internal/classroom/database/database.go
@@ -89,9 +89,9 @@ func dbError(err error) error {
 	}
 
 	//nolint:gocritic
-	switch err.(type) {
+	switch err := err.(type) {
 	case *mysql.MySQLError:
-		if err.(*mysql.MySQLError).Number == 1062 {
+		if err.Number == 1062 {
 			return fmt.Errorf("%w: %s", ErrAlreadyExists, err)
 		}
 		return fmt.Errorf("%w: %s", ErrUnknown, err)

--- a/api/internal/lesson/api/api.go
+++ b/api/internal/lesson/api/api.go
@@ -57,6 +57,8 @@ func gRPCError(err error) error {
 		return status.Error(codes.InvalidArgument, err.Error())
 	case errors.Is(err, database.ErrNotFound):
 		return status.Error(codes.NotFound, err.Error())
+	case errors.Is(err, database.ErrAlreadyExists):
+		return status.Error(codes.AlreadyExists, err.Error())
 	case errors.Is(err, database.ErrNotImplemented):
 		return status.Error(codes.Unimplemented, err.Error())
 	default:

--- a/api/internal/lesson/api/api_test.go
+++ b/api/internal/lesson/api/api_test.go
@@ -148,6 +148,11 @@ func TestGRPCError(t *testing.T) {
 			expect: codes.NotFound,
 		},
 		{
+			name:   "already exists",
+			err:    fmt.Errorf("%w: %s", database.ErrAlreadyExists, "test"),
+			expect: codes.AlreadyExists,
+		},
+		{
 			name:   "unimplemented",
 			err:    fmt.Errorf("%w: %s", database.ErrNotImplemented, "test"),
 			expect: codes.Unimplemented,

--- a/api/internal/lesson/database/database.go
+++ b/api/internal/lesson/database/database.go
@@ -70,9 +70,9 @@ func dbError(err error) error {
 	}
 
 	//nolint:gocritic
-	switch err.(type) {
+	switch err := err.(type) {
 	case *mysql.MySQLError:
-		if err.(*mysql.MySQLError).Number == 1062 {
+		if err.Number == 1062 {
 			return fmt.Errorf("%w: %s", ErrAlreadyExists, err)
 		}
 		return fmt.Errorf("%w: %s", ErrUnknown, err)

--- a/api/internal/lesson/database/database.go
+++ b/api/internal/lesson/database/database.go
@@ -16,6 +16,7 @@ import (
 var (
 	ErrInvalidArgument = errors.New("database: invalid argument")
 	ErrNotFound        = errors.New("database: not found")
+	ErrAlreadyExists   = errors.New("database: already exists")
 	ErrNotImplemented  = errors.New("database: not implemented")
 	ErrInternal        = errors.New("database: internal")
 	ErrUnknown         = errors.New("database: unknown")
@@ -71,6 +72,9 @@ func dbError(err error) error {
 	//nolint:gocritic
 	switch err.(type) {
 	case *mysql.MySQLError:
+		if err.(*mysql.MySQLError).Number == 1062 {
+			return fmt.Errorf("%w: %s", ErrAlreadyExists, err)
+		}
 		return fmt.Errorf("%w: %s", ErrUnknown, err)
 	}
 

--- a/api/internal/user/database/database.go
+++ b/api/internal/user/database/database.go
@@ -76,6 +76,9 @@ func dbError(err error) error {
 	//nolint:gocritic
 	switch err.(type) {
 	case *mysql.MySQLError:
+		if err.(*mysql.MySQLError).Number == 1062 {
+			return fmt.Errorf("%w: %s", ErrAlreadyExists, err)
+		}
 		return fmt.Errorf("%w: %s", ErrUnknown, err)
 	}
 

--- a/api/internal/user/database/database.go
+++ b/api/internal/user/database/database.go
@@ -74,9 +74,9 @@ func dbError(err error) error {
 	}
 
 	//nolint:gocritic
-	switch err.(type) {
+	switch err := err.(type) {
 	case *mysql.MySQLError:
-		if err.(*mysql.MySQLError).Number == 1062 {
+		if err.Number == 1062 {
 			return fmt.Errorf("%w: %s", ErrAlreadyExists, err)
 		}
 		return fmt.Errorf("%w: %s", ErrUnknown, err)


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
データがすでに存在するときのエラーハンドリングができていなかったため、409 (Conflict) のステータスが変えるような実装を追加しました

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
* closes https://github.com/calmato/shs-web/issues/72