### PR TITLE
feat(lesson-api): implement update shift summary schedule

### DIFF
--- a/api/internal/lesson/api/shift.go
+++ b/api/internal/lesson/api/shift.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/calmato/shs-web/api/internal/lesson/database"
 	"github.com/calmato/shs-web/api/internal/lesson/entity"
+	"github.com/calmato/shs-web/api/pkg/jst"
 	"github.com/calmato/shs-web/api/proto/classroom"
 	"github.com/calmato/shs-web/api/proto/lesson"
 	"golang.org/x/sync/errgroup"
@@ -81,6 +82,22 @@ func (s *lessonService) GetShiftSummary(
 		Summary: summary.Proto(),
 	}
 	return res, nil
+}
+
+func (s *lessonService) UpdateShiftSummarySchedule(
+	ctx context.Context, req *lesson.UpdateShiftSummaryScheduleRequest,
+) (*lesson.UpdateShiftSummaryShceduleResponse, error) {
+	if err := s.validator.UpdateShiftSummarySchedule(req); err != nil {
+		return nil, gRPCError(err)
+	}
+
+	openAt := jst.ParseFromUnix(req.OpenAt)
+	endAt := jst.ParseFromUnix(req.EndAt)
+	err := s.db.ShiftSummary.UpdateSchedule(ctx, req.Id, openAt, endAt)
+	if err != nil {
+		return nil, gRPCError(err)
+	}
+	return &lesson.UpdateShiftSummaryShceduleResponse{}, nil
 }
 
 func (s *lessonService) ListShifts(

--- a/api/internal/lesson/database/database.go
+++ b/api/internal/lesson/database/database.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/calmato/shs-web/api/internal/lesson/entity"
 	"github.com/calmato/shs-web/api/pkg/database"
@@ -43,6 +44,7 @@ func NewDatabase(params *Params) *Database {
 type ShiftSummary interface {
 	List(ctx context.Context, p *ListShiftSummariesParams, fields ...string) (entity.ShiftSummaries, error)
 	Get(ctx context.Context, id int64, fields ...string) (*entity.ShiftSummary, error)
+	UpdateSchedule(ctx context.Context, id int64, openAt, endAt time.Time) error
 	Count(ctx context.Context) (int64, error)
 }
 

--- a/api/internal/lesson/database/shift_summary_test.go
+++ b/api/internal/lesson/database/shift_summary_test.go
@@ -168,6 +168,63 @@ func TestShiftSummary_Get(t *testing.T) {
 	}
 }
 
+func TestShiftSummary_UpdateSchedule(t *testing.T) {
+	m, err := newMock()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_ = m.dbDelete(ctx, shiftSummaryTable)
+
+	now := jst.Now()
+	summary := testShiftSummary(1, 202202, now.AddDate(0, 0, -1), now.AddDate(0, 0, 1), now)
+
+	type args struct {
+		summaryID int64
+		openAt    time.Time
+		endAt     time.Time
+	}
+	type want struct {
+		isErr bool
+	}
+	tests := []struct {
+		name  string
+		setup func(ctx context.Context, t *testing.T, m *mocks)
+		args  args
+		want  want
+	}{
+		{
+			name: "success",
+			setup: func(ctx context.Context, t *testing.T, m *mocks) {
+				err = m.db.DB.Create(&summary).Error
+				require.NoError(t, err)
+			},
+			args: args{
+				summaryID: 1,
+				openAt:    jst.Now(),
+				endAt:     jst.Now(),
+			},
+			want: want{
+				isErr: false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			_ = m.dbDelete(ctx, shiftSummaryTable)
+			tt.setup(ctx, t, m)
+
+			db := NewShiftSummary(m.db)
+			err := db.UpdateSchedule(ctx, tt.args.summaryID, tt.args.openAt, tt.args.endAt)
+			assert.Equal(t, tt.want.isErr, err != nil, err)
+		})
+	}
+}
+
 func TestShiftSummary_Count(t *testing.T) {
 	m, err := newMock()
 	require.NoError(t, err)

--- a/api/internal/lesson/validation/shift.go
+++ b/api/internal/lesson/validation/shift.go
@@ -20,6 +20,15 @@ func (v *requestValidation) GetShiftSummary(req *lesson.GetShiftSummaryRequest) 
 	return nil
 }
 
+func (v *requestValidation) UpdateShiftSummarySchedule(req *lesson.UpdateShiftSummaryScheduleRequest) error {
+	if err := req.Validate(); err != nil {
+		validate := err.(lesson.UpdateShiftSummaryScheduleRequestValidationError)
+		return validationError(validate.Error())
+	}
+
+	return nil
+}
+
 func (v *requestValidation) ListShifts(req *lesson.ListShiftsRequest) error {
 	if err := req.Validate(); err != nil {
 		validate := err.(lesson.ListShiftsRequestValidationError)

--- a/api/internal/lesson/validation/shift_test.go
+++ b/api/internal/lesson/validation/shift_test.go
@@ -100,6 +100,63 @@ func TestGetShift(t *testing.T) {
 	}
 }
 
+func TestUpdateShiftSummarySchedule(t *testing.T) {
+	t.Parallel()
+	validator := NewRequestValidation()
+
+	tests := []struct {
+		name  string
+		req   *lesson.UpdateShiftSummaryScheduleRequest
+		isErr bool
+	}{
+		{
+			name: "success",
+			req: &lesson.UpdateShiftSummaryScheduleRequest{
+				Id:     1,
+				OpenAt: 1640940900,
+				EndAt:  1640940900,
+			},
+			isErr: false,
+		},
+		{
+			name: "Id is gt",
+			req: &lesson.UpdateShiftSummaryScheduleRequest{
+				Id:     0,
+				OpenAt: 1640940900,
+				EndAt:  1640940900,
+			},
+			isErr: true,
+		},
+		{
+			name: "OpenAt is gt",
+			req: &lesson.UpdateShiftSummaryScheduleRequest{
+				Id:     1,
+				OpenAt: 0,
+				EndAt:  1640940900,
+			},
+			isErr: true,
+		},
+		{
+			name: "EndAt is gt",
+			req: &lesson.UpdateShiftSummaryScheduleRequest{
+				Id:     1,
+				OpenAt: 1640940900,
+				EndAt:  0,
+			},
+			isErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validator.UpdateShiftSummarySchedule(tt.req)
+			assert.Equal(t, tt.isErr, err != nil, err)
+		})
+	}
+}
+
 func TestListShifts(t *testing.T) {
 	t.Parallel()
 	validator := NewRequestValidation()

--- a/api/internal/lesson/validation/validator.go
+++ b/api/internal/lesson/validation/validator.go
@@ -14,6 +14,7 @@ var ErrRequestValidation = errors.New("validation: invalid argument")
 type RequestValidation interface {
 	ListShiftSummaries(req *lesson.ListShiftSummariesRequest) error
 	GetShiftSummary(req *lesson.GetShiftSummaryRequest) error
+	UpdateShiftSummarySchedule(req *lesson.UpdateShiftSummaryScheduleRequest) error
 	ListShifts(req *lesson.ListShiftsRequest) error
 	CreateShifts(req *lesson.CreateShiftsRequest) error
 }

--- a/api/mock/lesson/database/database.go
+++ b/api/mock/lesson/database/database.go
@@ -7,6 +7,7 @@ package mock_database
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	database "github.com/calmato/shs-web/api/internal/lesson/database"
 	entity "github.com/calmato/shs-web/api/internal/lesson/entity"
@@ -89,6 +90,20 @@ func (mr *MockShiftSummaryMockRecorder) List(ctx, p interface{}, fields ...inter
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, p}, fields...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockShiftSummary)(nil).List), varargs...)
+}
+
+// UpdateSchedule mocks base method.
+func (m *MockShiftSummary) UpdateSchedule(ctx context.Context, id int64, openAt, endAt time.Time) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateSchedule", ctx, id, openAt, endAt)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateSchedule indicates an expected call of UpdateSchedule.
+func (mr *MockShiftSummaryMockRecorder) UpdateSchedule(ctx, id, openAt, endAt interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSchedule", reflect.TypeOf((*MockShiftSummary)(nil).UpdateSchedule), ctx, id, openAt, endAt)
 }
 
 // MockShift is a mock of Shift interface.

--- a/api/mock/lesson/validation/validator.go
+++ b/api/mock/lesson/validation/validator.go
@@ -89,3 +89,17 @@ func (mr *MockRequestValidationMockRecorder) ListShifts(req interface{}) *gomock
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListShifts", reflect.TypeOf((*MockRequestValidation)(nil).ListShifts), req)
 }
+
+// UpdateShiftSummarySchedule mocks base method.
+func (m *MockRequestValidation) UpdateShiftSummarySchedule(req *lesson.UpdateShiftSummaryScheduleRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateShiftSummarySchedule", req)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateShiftSummarySchedule indicates an expected call of UpdateShiftSummarySchedule.
+func (mr *MockRequestValidationMockRecorder) UpdateShiftSummarySchedule(req interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateShiftSummarySchedule", reflect.TypeOf((*MockRequestValidation)(nil).UpdateShiftSummarySchedule), req)
+}

--- a/api/mock/proto/lesson/service_grpc.pb.go.go
+++ b/api/mock/proto/lesson/service_grpc.pb.go.go
@@ -116,6 +116,26 @@ func (mr *MockLessonServiceClientMockRecorder) ListShifts(ctx, in interface{}, o
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListShifts", reflect.TypeOf((*MockLessonServiceClient)(nil).ListShifts), varargs...)
 }
 
+// UpdateShiftSummarySchedule mocks base method.
+func (m *MockLessonServiceClient) UpdateShiftSummarySchedule(ctx context.Context, in *lesson.UpdateShiftSummaryScheduleRequest, opts ...grpc.CallOption) (*lesson.UpdateShiftSummaryShceduleResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpdateShiftSummarySchedule", varargs...)
+	ret0, _ := ret[0].(*lesson.UpdateShiftSummaryShceduleResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateShiftSummarySchedule indicates an expected call of UpdateShiftSummarySchedule.
+func (mr *MockLessonServiceClientMockRecorder) UpdateShiftSummarySchedule(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateShiftSummarySchedule", reflect.TypeOf((*MockLessonServiceClient)(nil).UpdateShiftSummarySchedule), varargs...)
+}
+
 // MockLessonServiceServer is a mock of LessonServiceServer interface.
 type MockLessonServiceServer struct {
 	ctrl     *gomock.Controller
@@ -197,6 +217,21 @@ func (m *MockLessonServiceServer) ListShifts(arg0 context.Context, arg1 *lesson.
 func (mr *MockLessonServiceServerMockRecorder) ListShifts(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListShifts", reflect.TypeOf((*MockLessonServiceServer)(nil).ListShifts), arg0, arg1)
+}
+
+// UpdateShiftSummarySchedule mocks base method.
+func (m *MockLessonServiceServer) UpdateShiftSummarySchedule(arg0 context.Context, arg1 *lesson.UpdateShiftSummaryScheduleRequest) (*lesson.UpdateShiftSummaryShceduleResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateShiftSummarySchedule", arg0, arg1)
+	ret0, _ := ret[0].(*lesson.UpdateShiftSummaryShceduleResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateShiftSummarySchedule indicates an expected call of UpdateShiftSummarySchedule.
+func (mr *MockLessonServiceServerMockRecorder) UpdateShiftSummarySchedule(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateShiftSummarySchedule", reflect.TypeOf((*MockLessonServiceServer)(nil).UpdateShiftSummarySchedule), arg0, arg1)
 }
 
 // mustEmbedUnimplementedLessonServiceServer mocks base method.

--- a/api/proto/lesson/service.proto
+++ b/api/proto/lesson/service.proto
@@ -13,6 +13,7 @@ import "lesson/shift_summary.proto";
 service LessonService {
   rpc ListShiftSummaries(ListShiftSummariesRequest) returns (ListShiftSummariesResponse);
   rpc GetShiftSummary(GetShiftSummaryRequest) returns (GetShiftSummaryResponse);
+  rpc UpdateShiftSummarySchedule(UpdateShiftSummaryScheduleRequest) returns (UpdateShiftSummaryShceduleResponse);
   rpc ListShifts(ListShiftsRequest) returns (ListShiftsResponse);
   rpc CreateShifts(CreateShiftsRequest) returns (CreateShiftsResponse);
 }
@@ -35,6 +36,14 @@ message GetShiftSummaryRequest {
 message GetShiftSummaryResponse {
   ShiftSummary summary = 1;
 }
+
+message UpdateShiftSummaryScheduleRequest {
+  int64 id      = 1 [(validate.rules).int64 = { gt: 0 }];
+  int64 open_at = 2 [(validate.rules).int64 = { gt: 0 }];
+  int64 end_at  = 3 [(validate.rules).int64 = { gt: 0 }];
+}
+
+message UpdateShiftSummaryShceduleResponse {}
 
 message ListShiftsRequest {
   int64 shift_summary_id = 1 [(validate.rules).int64 = { gt: 0 }];


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
シフト募集の期間を更新するためのAPIを実装しました

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
