### PR TITLE
fix(lesson-api): fix fill status after shift created

### DIFF
--- a/api/internal/lesson/api/shift.go
+++ b/api/internal/lesson/api/shift.go
@@ -177,6 +177,7 @@ func (s *lessonService) CreateShifts(
 		return nil, gRPCError(err)
 	}
 
+	summary.Fill(s.now())
 	res := &lesson.CreateShiftsResponse{
 		Summary: summary.Proto(),
 		Shifts:  shifts.Proto(),


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
シフト募集の登録後、募集ステータスの代入ができていなくUNKNOWNでレスポンスが返ってきてしまっていたため修正しました

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
