### PR TITLE
feat(api): add grpc error handling

### DIFF
--- a/api/internal/classroom/api/api.go
+++ b/api/internal/classroom/api/api.go
@@ -47,6 +47,10 @@ func gRPCError(err error) error {
 		return nil
 	}
 
+	if _, ok := status.FromError(err); ok {
+		return err
+	}
+
 	switch {
 	case errors.Is(err, validation.ErrRequestValidation),
 		errors.Is(err, database.ErrInvalidArgument):

--- a/api/internal/classroom/api/api_test.go
+++ b/api/internal/classroom/api/api_test.go
@@ -160,6 +160,11 @@ func TestGRPCError(t *testing.T) {
 			expect: codes.Unimplemented,
 		},
 		{
+			name:   "grpc error",
+			err:    status.Error(codes.Unavailable, "test"),
+			expect: codes.Unavailable,
+		},
+		{
 			name:   "other error",
 			err:    errmock,
 			expect: codes.Internal,

--- a/api/internal/lesson/api/api.go
+++ b/api/internal/lesson/api/api.go
@@ -51,6 +51,10 @@ func gRPCError(err error) error {
 		return nil
 	}
 
+	if _, ok := status.FromError(err); ok {
+		return err
+	}
+
 	switch {
 	case errors.Is(err, validation.ErrRequestValidation),
 		errors.Is(err, database.ErrInvalidArgument):

--- a/api/internal/lesson/api/api_test.go
+++ b/api/internal/lesson/api/api_test.go
@@ -158,6 +158,11 @@ func TestGRPCError(t *testing.T) {
 			expect: codes.Unimplemented,
 		},
 		{
+			name:   "grpc error",
+			err:    status.Error(codes.Unavailable, "test"),
+			expect: codes.Unavailable,
+		},
+		{
 			name:   "other error",
 			err:    errmock,
 			expect: codes.Internal,

--- a/api/internal/user/api/api.go
+++ b/api/internal/user/api/api.go
@@ -47,6 +47,10 @@ func gRPCError(err error) error {
 		return nil
 	}
 
+	if _, ok := status.FromError(err); ok {
+		return err
+	}
+
 	switch {
 	case errors.Is(err, validation.ErrRequestValidation),
 		errors.Is(err, database.ErrInvalidArgument):

--- a/api/internal/user/api/api_test.go
+++ b/api/internal/user/api/api_test.go
@@ -154,6 +154,11 @@ func TestGRPCError(t *testing.T) {
 			expect: codes.Unimplemented,
 		},
 		{
+			name:   "grpc error",
+			err:    status.Error(codes.Unavailable, "test"),
+			expect: codes.Unavailable,
+		},
+		{
 			name:   "other error",
 			err:    errmock,
 			expect: codes.Internal,


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
gRPC経由で返ってきたエラーをそのまま返せるように設定

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
