### PR TITLE
feat(web/teacher): implement desktop default layout

### DIFF
--- a/web/teacher/src/components/organisms/TheHeader.vue
+++ b/web/teacher/src/components/organisms/TheHeader.vue
@@ -1,8 +1,8 @@
 <template>
-  <v-app-bar app dark color="primary" class="px-2">
+  <v-app-bar app dark clipped-left color="primary" class="px-2">
     <v-toolbar-title>SHS Web</v-toolbar-title>
     <v-spacer />
-    <v-btn icon @click="onClick">
+    <v-btn class="hidden-md-and-up" icon @click="onClick">
       <v-icon v-if="overlay">mdi-close</v-icon>
       <v-icon v-else>mdi-menu</v-icon>
     </v-btn>
@@ -17,6 +17,10 @@ export default defineComponent({
     overlay: {
       type: Boolean,
       default: false,
+    },
+    showMenu: {
+      type: Boolean,
+      default: true,
     },
   },
 

--- a/web/teacher/src/components/organisms/TheSidebar.vue
+++ b/web/teacher/src/components/organisms/TheSidebar.vue
@@ -1,0 +1,54 @@
+<template>
+  <v-navigation-drawer app clipped mobile-breakpoint="960">
+    <!-- links -->
+    <v-list dense nav shaped>
+      <v-list-item-group v-model="selectedItem" color="primary">
+        <v-list-item v-for="item in items" :key="item.path" link @click="onClick(item)">
+          <v-list-item-icon>
+            <v-icon>{{ item.icon }}</v-icon>
+          </v-list-item-icon>
+          <v-list-item-content>
+            <v-list-item-title>{{ item.name }}</v-list-item-title>
+          </v-list-item-content>
+        </v-list-item>
+      </v-list-item-group>
+    </v-list>
+    <!-- footer -->
+    <template #append>
+      <v-divider />
+      <div align="center" class="pa-2 font-weight-thin">&copy; Calmato. All rights reserved.</div>
+    </template>
+  </v-navigation-drawer>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType, SetupContext } from '@nuxtjs/composition-api'
+import { Menu } from '~/types/props/setting'
+
+export default defineComponent({
+  props: {
+    current: {
+      type: String,
+      default: '',
+    },
+    items: {
+      type: Array as PropType<Menu[]>,
+      default: () => [],
+    },
+  },
+
+  setup(props, { emit }: SetupContext) {
+    const target: Menu | undefined = props.items.filter((item: Menu) => item.path === props.current).shift()
+    const selectedItem: number = target ? props.items.indexOf(target) : -1
+
+    const onClick = (item: Menu) => {
+      emit('click', item)
+    }
+
+    return {
+      selectedItem,
+      onClick,
+    }
+  },
+})
+</script>

--- a/web/teacher/src/layouts/default.vue
+++ b/web/teacher/src/layouts/default.vue
@@ -2,6 +2,7 @@
   <v-app class="root" :style="{ background }">
     <the-snackbar :snackbar.sync="snackbar" :color="snackbarColor" :message="snackbarMessage" />
     <the-header :overlay="overlay" @click="handleClickMenu" />
+    <the-sidebar :items="items" :current="current" @click="handleClickMenuItem" />
     <v-main>
       <nuxt />
       <the-menu
@@ -20,6 +21,7 @@ import { computed, defineComponent, ref, SetupContext, watch } from '@nuxtjs/com
 import { VuetifyThemeItem } from 'vuetify/types/services/theme'
 import TheHeader from '~/components/organisms/TheHeader.vue'
 import TheMenu from '~/components/organisms/TheMenu.vue'
+import TheSidebar from '~/components/organisms/TheSidebar.vue'
 import TheSnackbar from '~/components/organisms/TheSnackbar.vue'
 import { CommonStore } from '~/store'
 import { Menu } from '~/types/props/menu'
@@ -29,9 +31,11 @@ export default defineComponent({
     TheHeader,
     TheMenu,
     TheSnackbar,
+    TheSidebar,
   },
 
   setup(_, { root }: SetupContext) {
+    const route = root.$route
     const router = root.$router
     const store = root.$store
     const vuetify = root.$vuetify
@@ -76,6 +80,7 @@ export default defineComponent({
       return color
     }
 
+    const current = ref<string>(route.path)
     const snackbar = ref<Boolean>(false)
     const overlay = ref<boolean>(false)
     const background = ref<VuetifyThemeItem>(getBackgroundColor(root.$route.path))
@@ -86,6 +91,7 @@ export default defineComponent({
     watch(
       () => root.$route,
       (): void => {
+        current.value = root.$route.path
         background.value = getBackgroundColor(root.$route.path)
       }
     )
@@ -106,12 +112,13 @@ export default defineComponent({
 
     const handleClickMenuItem = (item: Menu): void => {
       router.push(item.path)
-      handleClickMenu()
+      overlay.value = false
     }
 
     return {
       items,
       overlay,
+      current,
       background,
       snackbar,
       snackbarColor,

--- a/web/teacher/test/components/organisms/TheSidebar.test.ts
+++ b/web/teacher/test/components/organisms/TheSidebar.test.ts
@@ -1,0 +1,63 @@
+import { shallowMount } from '@vue/test-utils'
+import * as Options from '~~/test/helpers/component-helper'
+import TheSidebar from '~/components/organisms/TheSidebar.vue'
+import { Menu } from '~/types/props/menu'
+
+describe('components/organisms/TheSidebar', () => {
+  let wrapper: any
+  beforeEach(() => {
+    wrapper = shallowMount(TheSidebar, {
+      ...Options,
+    })
+  })
+
+  describe('script', () => {
+    describe('data', () => {
+      it('selectedItem', () => {
+        expect(wrapper.vm.selectedItem).toBe(-1)
+      })
+    })
+
+    describe('props', () => {
+      describe('current', () => {
+        it('初期値', () => {
+          expect(wrapper.props().current).toBe('')
+        })
+
+        it('値が代入されること', async () => {
+          await wrapper.setProps({ current: '/test' })
+          expect(wrapper.props().current).toBe('/test')
+        })
+      })
+
+      describe('items', () => {
+        it('初期値', () => {
+          expect(wrapper.props().items).toEqual([])
+        })
+
+        it('値が代入されること', async () => {
+          const items: Menu[] = [
+            {
+              name: 'テスト',
+              icon: 'mdi-home',
+              path: '/test',
+            },
+          ]
+          await wrapper.setProps({ items })
+          expect(wrapper.props().items).toBe(items)
+        })
+      })
+    })
+
+    describe('methods', () => {
+      describe('onClick', () => {
+        it('emitted', async () => {
+          const item: Menu = { name: 'テスト', icon: 'mdi-home', path: '/test' }
+          await wrapper.vm.onClick(item)
+          expect(wrapper.emitted('click')).toBeTruthy()
+          expect(wrapper.emitted('click')[0][0]).toBe(item)
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
デスクトップで表示時の共通コンポーネントを実装

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
![localhost_3000_](https://user-images.githubusercontent.com/27718413/148006688-71a44301-f1f1-41ff-8f2e-a3fc805d0aa8.png)
