### PR TITLE
feat(classroom-api): define student subjects proto

### DIFF
--- a/api/mock/proto/classroom/service_grpc.pb.go.go
+++ b/api/mock/proto/classroom/service_grpc.pb.go.go
@@ -116,6 +116,26 @@ func (mr *MockClassroomServiceClientMockRecorder) GetSchedule(ctx, in interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSchedule", reflect.TypeOf((*MockClassroomServiceClient)(nil).GetSchedule), varargs...)
 }
 
+// GetStudentSubject mocks base method.
+func (m *MockClassroomServiceClient) GetStudentSubject(ctx context.Context, in *classroom.GetStudentSubjectRequest, opts ...grpc.CallOption) (*classroom.GetStudentSubjectResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetStudentSubject", varargs...)
+	ret0, _ := ret[0].(*classroom.GetStudentSubjectResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStudentSubject indicates an expected call of GetStudentSubject.
+func (mr *MockClassroomServiceClientMockRecorder) GetStudentSubject(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStudentSubject", reflect.TypeOf((*MockClassroomServiceClient)(nil).GetStudentSubject), varargs...)
+}
+
 // GetSubject mocks base method.
 func (m *MockClassroomServiceClient) GetSubject(ctx context.Context, in *classroom.GetSubjectRequest, opts ...grpc.CallOption) (*classroom.GetSubjectResponse, error) {
 	m.ctrl.T.Helper()
@@ -194,6 +214,26 @@ func (mr *MockClassroomServiceClientMockRecorder) ListSubjects(ctx, in interface
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSubjects", reflect.TypeOf((*MockClassroomServiceClient)(nil).ListSubjects), varargs...)
+}
+
+// MultiGetStudentSubjects mocks base method.
+func (m *MockClassroomServiceClient) MultiGetStudentSubjects(ctx context.Context, in *classroom.MultiGetStudentSubjectsRequest, opts ...grpc.CallOption) (*classroom.MultiGetStudentSubjectsResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "MultiGetStudentSubjects", varargs...)
+	ret0, _ := ret[0].(*classroom.MultiGetStudentSubjectsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MultiGetStudentSubjects indicates an expected call of MultiGetStudentSubjects.
+func (mr *MockClassroomServiceClientMockRecorder) MultiGetStudentSubjects(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MultiGetStudentSubjects", reflect.TypeOf((*MockClassroomServiceClient)(nil).MultiGetStudentSubjects), varargs...)
 }
 
 // MultiGetSubjects mocks base method.
@@ -294,6 +334,26 @@ func (mr *MockClassroomServiceClientMockRecorder) UpdateSubject(ctx, in interfac
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSubject", reflect.TypeOf((*MockClassroomServiceClient)(nil).UpdateSubject), varargs...)
+}
+
+// UpsertStudentSubject mocks base method.
+func (m *MockClassroomServiceClient) UpsertStudentSubject(ctx context.Context, in *classroom.UpsertStudentSubjectRequest, opts ...grpc.CallOption) (*classroom.UpsertStudentSubjectResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpsertStudentSubject", varargs...)
+	ret0, _ := ret[0].(*classroom.UpsertStudentSubjectResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpsertStudentSubject indicates an expected call of UpsertStudentSubject.
+func (mr *MockClassroomServiceClientMockRecorder) UpsertStudentSubject(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertStudentSubject", reflect.TypeOf((*MockClassroomServiceClient)(nil).UpsertStudentSubject), varargs...)
 }
 
 // UpsertTeacherSubject mocks base method.
@@ -399,6 +459,21 @@ func (mr *MockClassroomServiceServerMockRecorder) GetSchedule(arg0, arg1 interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSchedule", reflect.TypeOf((*MockClassroomServiceServer)(nil).GetSchedule), arg0, arg1)
 }
 
+// GetStudentSubject mocks base method.
+func (m *MockClassroomServiceServer) GetStudentSubject(arg0 context.Context, arg1 *classroom.GetStudentSubjectRequest) (*classroom.GetStudentSubjectResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetStudentSubject", arg0, arg1)
+	ret0, _ := ret[0].(*classroom.GetStudentSubjectResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStudentSubject indicates an expected call of GetStudentSubject.
+func (mr *MockClassroomServiceServerMockRecorder) GetStudentSubject(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStudentSubject", reflect.TypeOf((*MockClassroomServiceServer)(nil).GetStudentSubject), arg0, arg1)
+}
+
 // GetSubject mocks base method.
 func (m *MockClassroomServiceServer) GetSubject(arg0 context.Context, arg1 *classroom.GetSubjectRequest) (*classroom.GetSubjectResponse, error) {
 	m.ctrl.T.Helper()
@@ -457,6 +532,21 @@ func (m *MockClassroomServiceServer) ListSubjects(arg0 context.Context, arg1 *cl
 func (mr *MockClassroomServiceServerMockRecorder) ListSubjects(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSubjects", reflect.TypeOf((*MockClassroomServiceServer)(nil).ListSubjects), arg0, arg1)
+}
+
+// MultiGetStudentSubjects mocks base method.
+func (m *MockClassroomServiceServer) MultiGetStudentSubjects(arg0 context.Context, arg1 *classroom.MultiGetStudentSubjectsRequest) (*classroom.MultiGetStudentSubjectsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MultiGetStudentSubjects", arg0, arg1)
+	ret0, _ := ret[0].(*classroom.MultiGetStudentSubjectsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MultiGetStudentSubjects indicates an expected call of MultiGetStudentSubjects.
+func (mr *MockClassroomServiceServerMockRecorder) MultiGetStudentSubjects(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MultiGetStudentSubjects", reflect.TypeOf((*MockClassroomServiceServer)(nil).MultiGetStudentSubjects), arg0, arg1)
 }
 
 // MultiGetSubjects mocks base method.
@@ -532,6 +622,21 @@ func (m *MockClassroomServiceServer) UpdateSubject(arg0 context.Context, arg1 *c
 func (mr *MockClassroomServiceServerMockRecorder) UpdateSubject(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSubject", reflect.TypeOf((*MockClassroomServiceServer)(nil).UpdateSubject), arg0, arg1)
+}
+
+// UpsertStudentSubject mocks base method.
+func (m *MockClassroomServiceServer) UpsertStudentSubject(arg0 context.Context, arg1 *classroom.UpsertStudentSubjectRequest) (*classroom.UpsertStudentSubjectResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpsertStudentSubject", arg0, arg1)
+	ret0, _ := ret[0].(*classroom.UpsertStudentSubjectResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpsertStudentSubject indicates an expected call of UpsertStudentSubject.
+func (mr *MockClassroomServiceServerMockRecorder) UpsertStudentSubject(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertStudentSubject", reflect.TypeOf((*MockClassroomServiceServer)(nil).UpsertStudentSubject), arg0, arg1)
 }
 
 // UpsertTeacherSubject mocks base method.

--- a/api/proto/classroom/service.proto
+++ b/api/proto/classroom/service.proto
@@ -8,6 +8,7 @@ import "github.com/envoyproxy/protoc-gen-validate/validate/validate.proto";
 
 import "classroom/common.proto";
 import "classroom/schedule.proto";
+import "classroom/student_subject.proto";
 import "classroom/subject.proto";
 import "classroom/teacher_subject.proto";
 
@@ -21,6 +22,9 @@ service ClassroomService {
   rpc MultiGetTeacherSubjects(MultiGetTeacherSubjectsRequest) returns (MultiGetTeacherSubjectsResponse);
   rpc GetTeacherSubject(GetTeacherSubjectRequest) returns (GetTeacherSubjectResponse);
   rpc UpsertTeacherSubject(UpsertTeacherSubjectRequest) returns (UpsertTeacherSubjectResponse);
+  rpc MultiGetStudentSubjects(MultiGetStudentSubjectsRequest) returns (MultiGetStudentSubjectsResponse);
+  rpc GetStudentSubject(GetStudentSubjectRequest) returns (GetStudentSubjectResponse);
+  rpc UpsertStudentSubject(UpsertStudentSubjectRequest) returns (UpsertStudentSubjectResponse);
   rpc ListSchedules(ListSchedulesRequest) returns (ListSchedulesResponse);
   rpc GetSchedule(GetScheduleRequest) returns (GetScheduleResponse);
   rpc UpdateSchedules(UpdateSchedulesRequest) returns (UpdateSchedulesResponse);
@@ -103,6 +107,32 @@ message UpsertTeacherSubjectRequest {
 }
 
 message UpsertTeacherSubjectResponse {}
+
+message MultiGetStudentSubjectsRequest {
+  repeated string student_ids = 1 [(validate.rules).repeated = { min_items: 1, unique: true, items: { string: { min_len: 1 }}}];
+}
+
+message MultiGetStudentSubjectsResponse {
+  repeated StudentSubject student_subjects = 1;
+  repeated Subject        subjects = 2;
+}
+
+message GetStudentSubjectRequest {
+  string student_id = 1 [(validate.rules).string = { min_len: 1 }];
+}
+
+message GetStudentSubjectResponse {
+  StudentSubject   student_subject = 1;
+  repeated Subject subjects        = 2;
+}
+
+message UpsertStudentSubjectRequest {
+  string         student_id  = 1 [(validate.rules).string = { min_len: 1 }];
+  repeated int64 subject_ids = 2 [(validate.rules).repeated = { unique: true, items: { int64: { gt: 0 }}}];
+  SchoolType     school_type = 3 [(validate.rules).enum = { defined_only: true }];
+}
+
+message UpsertStudentSubjectResponse {}
 
 message ListSchedulesRequest {}
 

--- a/api/proto/classroom/student_subject.proto
+++ b/api/proto/classroom/student_subject.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package classroom;
+
+option go_package = "github.com/calmato/shs-web/api/proto/classroom";
+
+message StudentSubject {
+  string         student_id  = 1; // 生徒ID
+  repeated int64 subject_ids = 2; // 受講科目ID一覧
+}

--- a/infra/mysql/schema/2022010401-classrooms-create-table-student-subjects.sql
+++ b/infra/mysql/schema/2022010401-classrooms-create-table-student-subjects.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `classrooms`.`student_subjects` (
+  `student_id` VARCHAR(22) NOT NULL, -- 生徒ID
+  `subject_id` BIGINT      NOT NULL, -- 授業科目ID
+  `created_at` DATETIME    NOT NULL, -- 登録日時
+  `updated_at` DATETIME    NOT NULL, -- 更新日時
+  PRIMARY KEY(`student_id`, `subject_id`),
+  CONSTRAINT `fk_student_subjects_subjects_id`
+    FOREIGN KEY (`subject_id`) REFERENCES `classrooms`.`subjects` (`id`)
+    ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE = InnoDB;
+
+CREATE INDEX `idx_student_subjects_subject_id_student_id`
+  ON `classrooms`.`student_subjects` (`subject_id` ASC, `student_id` ASC) VISIBLE;


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
生徒の受講教科管理用APIの実装にあたり、まずはprotoの定義をしました

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
