### PR TITLE
feat(classroom-api): implement student subjects db logic

### DIFF
--- a/api/internal/classroom/database/database.go
+++ b/api/internal/classroom/database/database.go
@@ -31,6 +31,7 @@ type Params struct {
 type Database struct {
 	Subject        Subject
 	TeacherSubject TeacherSubject
+	StudentSubject StudentSubject
 	Schedule       Schedule
 	Room           Room
 }
@@ -39,6 +40,7 @@ func NewDatabase(params *Params) *Database {
 	return &Database{
 		Subject:        NewSubject(params.Database),
 		TeacherSubject: NewTeacherSubject(params.Database),
+		StudentSubject: NewStudentSubject(params.Database),
 		Schedule:       NewSchedule(params.Database),
 		Room:           NewRoom(params.Database),
 	}
@@ -60,6 +62,11 @@ type Subject interface {
 type TeacherSubject interface {
 	ListByTeacherIDs(ctx context.Context, teacherIDs []string, fields ...string) (entity.TeacherSubjects, error)
 	Replace(ctx context.Context, schoolType entity.SchoolType, subjects entity.TeacherSubjects) error
+}
+
+type StudentSubject interface {
+	ListByStudentIDs(ctx context.Context, studentIDs []string, fields ...string) (entity.StudentSubjects, error)
+	Replace(ctx context.Context, schoolType entity.SchoolType, subjects entity.StudentSubjects) error
 }
 
 type Schedule interface {

--- a/api/internal/classroom/database/student_subject.go
+++ b/api/internal/classroom/database/student_subject.go
@@ -1,0 +1,89 @@
+package database
+
+import (
+	"context"
+	"time"
+
+	"github.com/calmato/shs-web/api/internal/classroom/entity"
+	"github.com/calmato/shs-web/api/pkg/database"
+	"github.com/calmato/shs-web/api/pkg/jst"
+)
+
+const studentSubjectTable = "student_subjects"
+
+var studentSubjectFields = []string{
+	"student_id", "subject_id", "created_at", "updated_at",
+}
+
+type studentSubject struct {
+	db  *database.Client
+	now func() time.Time
+}
+
+func NewStudentSubject(db *database.Client) StudentSubject {
+	return &studentSubject{
+		db:  db,
+		now: jst.Now,
+	}
+}
+
+func (s *studentSubject) ListByStudentIDs(
+	ctx context.Context, studentIDs []string, fields ...string,
+) (entity.StudentSubjects, error) {
+	var subjects entity.StudentSubjects
+	if len(fields) == 0 {
+		fields = studentSubjectFields
+	}
+
+	stmt := s.db.DB.Table(studentSubjectTable).Select(fields).
+		Where("student_id IN (?)", studentIDs)
+
+	err := stmt.Find(&subjects).Error
+	return subjects, dbError(err)
+}
+
+func (s *studentSubject) Replace(
+	ctx context.Context, schoolType entity.SchoolType, subjects entity.StudentSubjects,
+) error {
+	now := s.now()
+	for i := range subjects {
+		subjects[i].CreatedAt = now
+		subjects[i].UpdatedAt = now
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return dbError(err)
+	}
+	defer s.db.Close(tx)
+
+	studentID := subjects.StudentID()
+
+	var subjectIDs []int64
+	err = tx.Table(studentSubjectTable).Select("subjects.id").
+		Joins("LEFT JOIN subjects ON student_subjects.subject_id = subjects.id").
+		Where("student_subjects.student_id = ?", studentID).
+		Where("subjects.school_type = ?", schoolType).
+		Find(&subjectIDs).Error
+	if err != nil {
+		return dbError(err)
+	}
+
+	err = tx.Table(studentSubjectTable).
+		Where("student_id = ?", studentID).
+		Where("subject_id IN (?)", subjectIDs).
+		Delete(&entity.StudentSubject{}).Error
+	if err != nil {
+		tx.Rollback()
+		return dbError(err)
+	}
+
+	if len(subjects) > 0 {
+		err = tx.Table(studentSubjectTable).Create(&subjects).Error
+		if err != nil {
+			tx.Rollback()
+			return dbError(err)
+		}
+	}
+	return dbError(tx.Commit().Error)
+}

--- a/api/internal/classroom/database/student_subject_test.go
+++ b/api/internal/classroom/database/student_subject_test.go
@@ -1,0 +1,224 @@
+package database
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/calmato/shs-web/api/internal/classroom/entity"
+	"github.com/calmato/shs-web/api/pkg/jst"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStudentSubject_List(t *testing.T) {
+	m, err := newMock()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_ = m.dbDelete(ctx, studentSubjectTable, subjectTable)
+
+	now := jst.Now()
+
+	const studentID1, studentID2 = "studentid1", "studentid2"
+
+	subjects := make(entity.Subjects, 3)
+	subjects[0] = testSubject(1, "国語", entity.SchoolTypeElementarySchool, now)
+	subjects[1] = testSubject(2, "数学", entity.SchoolTypeJuniorHighSchool, now)
+	subjects[2] = testSubject(3, "英語", entity.SchoolTypeHighSchool, now)
+	err = m.db.DB.Create(&subjects).Error
+	require.NoError(t, err)
+
+	studentSubjects := make(entity.StudentSubjects, 4)
+	studentSubjects[0] = testStudentSubject(studentID1, 1, now)
+	studentSubjects[1] = testStudentSubject(studentID1, 2, now)
+	studentSubjects[2] = testStudentSubject(studentID1, 3, now)
+	studentSubjects[3] = testStudentSubject(studentID2, 1, now)
+	err = m.db.DB.Create(&studentSubjects).Error
+	require.NoError(t, err)
+
+	type args struct {
+		studentIDs []string
+	}
+	type want struct {
+		subjects entity.StudentSubjects
+		isErr    bool
+	}
+	tests := []struct {
+		name  string
+		setup func(ctx context.Context, t *testing.T, m *mocks)
+		args  args
+		want  want
+	}{
+		{
+			name:  "success",
+			setup: func(ctx context.Context, t *testing.T, m *mocks) {},
+			args: args{
+				studentIDs: []string{studentID1, studentID2},
+			},
+			want: want{
+				subjects: studentSubjects,
+				isErr:    false,
+			},
+		},
+		{
+			name:  "success empty",
+			setup: func(ctx context.Context, t *testing.T, m *mocks) {},
+			args: args{
+				studentIDs: []string{},
+			},
+			want: want{
+				subjects: entity.StudentSubjects{},
+				isErr:    false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			tt.setup(ctx, t, m)
+
+			db := NewStudentSubject(m.db)
+			actual, err := db.ListByStudentIDs(ctx, tt.args.studentIDs)
+			assert.Equal(t, tt.want.isErr, err != nil, err)
+			for i, subject := range tt.want.subjects {
+				subject.CreatedAt = actual[i].CreatedAt
+				subject.UpdatedAt = actual[i].UpdatedAt
+				assert.Contains(t, actual, subject)
+			}
+		})
+	}
+}
+
+func TestStudentSubject_Replace(t *testing.T) {
+	m, err := newMock()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_ = m.dbDelete(ctx, studentSubjectTable, subjectTable)
+
+	now := jst.Now()
+
+	const studentID1, studentID2 = "studentid1", "studentid2"
+
+	subjects := make(entity.Subjects, 5)
+	subjects[0] = testSubject(1, "国語", entity.SchoolTypeElementarySchool, now)
+	subjects[1] = testSubject(2, "数学", entity.SchoolTypeJuniorHighSchool, now)
+	subjects[2] = testSubject(3, "社会", entity.SchoolTypeHighSchool, now)
+	subjects[3] = testSubject(4, "理科", entity.SchoolTypeHighSchool, now)
+	subjects[4] = testSubject(5, "英語", entity.SchoolTypeHighSchool, now)
+	err = m.db.DB.Create(&subjects).Error
+	require.NoError(t, err)
+
+	studentSubjects := make(entity.StudentSubjects, 4)
+	studentSubjects[0] = testStudentSubject(studentID1, 1, now)
+	studentSubjects[1] = testStudentSubject(studentID1, 2, now)
+	studentSubjects[2] = testStudentSubject(studentID1, 3, now)
+	studentSubjects[2] = testStudentSubject(studentID1, 4, now)
+	studentSubjects[3] = testStudentSubject(studentID2, 1, now)
+
+	type args struct {
+		schoolType entity.SchoolType
+		subjects   entity.StudentSubjects
+	}
+	type want struct {
+		isErr bool
+	}
+	tests := []struct {
+		name  string
+		setup func(ctx context.Context, t *testing.T, m *mocks)
+		args  args
+		want  want
+	}{
+		{
+			name:  "success when empty",
+			setup: func(ctx context.Context, t *testing.T, m *mocks) {},
+			args: args{
+				schoolType: entity.SchoolTypeHighSchool,
+				subjects: entity.StudentSubjects{
+					testStudentSubject(studentID1, 3, now),
+					testStudentSubject(studentID1, 4, now),
+					testStudentSubject(studentID1, 5, now),
+				},
+			},
+			want: want{
+				isErr: false,
+			},
+		},
+		{
+			name: "success when exists",
+			setup: func(ctx context.Context, t *testing.T, m *mocks) {
+				err := m.db.DB.Create(studentSubjects).Error
+				require.NoError(t, err)
+			},
+			args: args{
+				schoolType: entity.SchoolTypeHighSchool,
+				subjects: entity.StudentSubjects{
+					testStudentSubject(studentID1, 4, now),
+					testStudentSubject(studentID1, 5, now),
+				},
+			},
+			want: want{
+				isErr: false,
+			},
+		},
+		{
+			name: "success to subject length is 0",
+			setup: func(ctx context.Context, t *testing.T, m *mocks) {
+				err := m.db.DB.Create(studentSubjects).Error
+				require.NoError(t, err)
+			},
+			args: args{
+				schoolType: entity.SchoolTypeHighSchool,
+				subjects:   entity.StudentSubjects{},
+			},
+			want: want{
+				isErr: false,
+			},
+		},
+		{
+			name:  "failed to insert subject",
+			setup: func(ctx context.Context, t *testing.T, m *mocks) {},
+			args: args{
+				schoolType: entity.SchoolTypeHighSchool,
+				subjects: entity.StudentSubjects{
+					testStudentSubject(studentID1, 0, now),
+				},
+			},
+			want: want{
+				isErr: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			_ = m.dbDelete(ctx, studentSubjectTable)
+			tt.setup(ctx, t, m)
+
+			db := NewStudentSubject(m.db)
+			err := db.Replace(ctx, tt.args.schoolType, tt.args.subjects)
+			assert.Equal(t, tt.want.isErr, err != nil, err)
+		})
+	}
+}
+
+func testStudentSubject(studentID string, subjectID int64, now time.Time) *entity.StudentSubject {
+	return &entity.StudentSubject{
+		StudentID: studentID,
+		SubjectID: subjectID,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+}

--- a/api/internal/classroom/entity/student_subject.go
+++ b/api/internal/classroom/entity/student_subject.go
@@ -1,0 +1,83 @@
+package entity
+
+import (
+	"time"
+
+	"github.com/calmato/shs-web/api/pkg/set"
+	"github.com/calmato/shs-web/api/proto/classroom"
+)
+
+type StudentSubject struct {
+	StudentID string    `gorm:"primaryKey;<-:create"`
+	SubjectID int64     `gorm:"primaryKey;<-:create"`
+	CreatedAt time.Time `gorm:"<-:create"`
+	UpdatedAt time.Time `gorm:""`
+}
+
+type StudentSubjects []*StudentSubject
+
+func NewStudentSubjects(studentID string, subjectIDs []int64) StudentSubjects {
+	subjects := make(StudentSubjects, len(subjectIDs))
+	for i := range subjectIDs {
+		subject := &StudentSubject{
+			StudentID: studentID,
+			SubjectID: subjectIDs[i],
+		}
+		subjects[i] = subject
+	}
+	return subjects
+}
+
+func (ss StudentSubjects) StudentID() string {
+	if len(ss) == 0 {
+		return ""
+	}
+	return ss[0].StudentID
+}
+
+func (ss StudentSubjects) SubjectIDs() []int64 {
+	set := set.New(len(ss))
+	for _, s := range ss {
+		set.AddInt64s(s.SubjectID)
+	}
+	return set.Int64s()
+}
+
+func (ss StudentSubjects) GroupByStudentID() map[string]StudentSubjects {
+	subjects := make(map[string]StudentSubjects)
+	for _, s := range ss {
+		if _, ok := subjects[s.StudentID]; !ok {
+			subjects[s.StudentID] = make(StudentSubjects, 0)
+		}
+		subjects[s.StudentID] = append(subjects[s.StudentID], s)
+	}
+	return subjects
+}
+
+func (ss StudentSubjects) StudentProto() *classroom.StudentSubject {
+	if len(ss) == 0 {
+		return nil
+	}
+
+	studentID := ss[0].StudentID
+	subjects := make([]int64, len(ss))
+	for i := range ss {
+		subjects[i] = ss[i].SubjectID
+	}
+
+	return &classroom.StudentSubject{
+		StudentId:  studentID,
+		SubjectIds: subjects,
+	}
+}
+
+func (ss StudentSubjects) StudentsProto() []*classroom.StudentSubject {
+	subjectsMap := ss.GroupByStudentID()
+
+	res := make([]*classroom.StudentSubject, 0, len(subjectsMap))
+	for _, subjects := range subjectsMap {
+		subject := subjects.StudentProto()
+		res = append(res, subject)
+	}
+	return res
+}

--- a/api/internal/classroom/entity/student_subject_test.go
+++ b/api/internal/classroom/entity/student_subject_test.go
@@ -1,0 +1,251 @@
+package entity
+
+import (
+	"testing"
+
+	"github.com/calmato/shs-web/api/pkg/jst"
+	"github.com/calmato/shs-web/api/proto/classroom"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStudentSubjects(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		studentID  string
+		subjectIDs []int64
+		expect     StudentSubjects
+	}{
+		{
+			name:       "success",
+			studentID:  "studentid",
+			subjectIDs: []int64{1},
+			expect: StudentSubjects{
+				{
+					StudentID: "studentid",
+					SubjectID: 1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, NewStudentSubjects(tt.studentID, tt.subjectIDs))
+		})
+	}
+}
+
+func TestStudentSubject_SubjectIDs(t *testing.T) {
+	t.Parallel()
+	now := jst.Now()
+	tests := []struct {
+		name     string
+		subjects StudentSubjects
+		expect   []int64
+	}{
+		{
+			name: "success",
+			subjects: StudentSubjects{
+				{
+					StudentID: "studentid1",
+					SubjectID: 1,
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+				{
+					StudentID: "studentid1",
+					SubjectID: 2,
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+				{
+					StudentID: "studentid2",
+					SubjectID: 1,
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+			},
+			expect: []int64{1, 2},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			subjectIDs := tt.subjects.SubjectIDs()
+			for _, subjectID := range tt.expect {
+				assert.Contains(t, subjectIDs, subjectID)
+			}
+		})
+	}
+}
+
+func TestStudentSubject_GroupByStudentID(t *testing.T) {
+	t.Parallel()
+	now := jst.Now()
+	tests := []struct {
+		name     string
+		subjects StudentSubjects
+		expect   map[string]StudentSubjects
+	}{
+		{
+			name: "success",
+			subjects: StudentSubjects{
+				{
+					StudentID: "studentid1",
+					SubjectID: 1,
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+				{
+					StudentID: "studentid1",
+					SubjectID: 2,
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+				{
+					StudentID: "studentid2",
+					SubjectID: 1,
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+			},
+			expect: map[string]StudentSubjects{
+				"studentid1": {
+					{
+						StudentID: "studentid1",
+						SubjectID: 1,
+						CreatedAt: now,
+						UpdatedAt: now,
+					},
+					{
+						StudentID: "studentid1",
+						SubjectID: 2,
+						CreatedAt: now,
+						UpdatedAt: now,
+					},
+				},
+				"studentid2": {
+					{
+						StudentID: "studentid2",
+						SubjectID: 1,
+						CreatedAt: now,
+						UpdatedAt: now,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.subjects.GroupByStudentID())
+		})
+	}
+}
+
+func TestStudentSubject_StudentProto(t *testing.T) {
+	t.Parallel()
+	now := jst.Now()
+	tests := []struct {
+		name     string
+		subjects StudentSubjects
+		expect   *classroom.StudentSubject
+	}{
+		{
+			name: "success",
+			subjects: StudentSubjects{
+				{
+					StudentID: "studentid1",
+					SubjectID: 1,
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+				{
+					StudentID: "studentid1",
+					SubjectID: 2,
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+			},
+			expect: &classroom.StudentSubject{
+				StudentId:  "studentid1",
+				SubjectIds: []int64{1, 2},
+			},
+		},
+		{
+			name:     "success empty",
+			subjects: StudentSubjects{},
+			expect:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.subjects.StudentProto())
+		})
+	}
+}
+
+func TestStudentSubject_StudentsProto(t *testing.T) {
+	t.Parallel()
+	now := jst.Now()
+	tests := []struct {
+		name     string
+		subjects StudentSubjects
+		expect   []*classroom.StudentSubject
+	}{
+		{
+			name: "success",
+			subjects: StudentSubjects{
+				{
+					StudentID: "studentid1",
+					SubjectID: 1,
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+				{
+					StudentID: "studentid1",
+					SubjectID: 2,
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+				{
+					StudentID: "studentid2",
+					SubjectID: 1,
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+			},
+			expect: []*classroom.StudentSubject{
+				{
+					StudentId:  "studentid1",
+					SubjectIds: []int64{1, 2},
+				},
+				{
+					StudentId:  "studentid2",
+					SubjectIds: []int64{1},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := tt.subjects.StudentsProto()
+			for i := range tt.expect {
+				assert.Contains(t, actual, tt.expect[i])
+			}
+		})
+	}
+}

--- a/api/mock/classroom/database/database.go
+++ b/api/mock/classroom/database/database.go
@@ -211,6 +211,63 @@ func (mr *MockTeacherSubjectMockRecorder) Replace(ctx, schoolType, subjects inte
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Replace", reflect.TypeOf((*MockTeacherSubject)(nil).Replace), ctx, schoolType, subjects)
 }
 
+// MockStudentSubject is a mock of StudentSubject interface.
+type MockStudentSubject struct {
+	ctrl     *gomock.Controller
+	recorder *MockStudentSubjectMockRecorder
+}
+
+// MockStudentSubjectMockRecorder is the mock recorder for MockStudentSubject.
+type MockStudentSubjectMockRecorder struct {
+	mock *MockStudentSubject
+}
+
+// NewMockStudentSubject creates a new mock instance.
+func NewMockStudentSubject(ctrl *gomock.Controller) *MockStudentSubject {
+	mock := &MockStudentSubject{ctrl: ctrl}
+	mock.recorder = &MockStudentSubjectMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockStudentSubject) EXPECT() *MockStudentSubjectMockRecorder {
+	return m.recorder
+}
+
+// ListByStudentIDs mocks base method.
+func (m *MockStudentSubject) ListByStudentIDs(ctx context.Context, studentIDs []string, fields ...string) (entity.StudentSubjects, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, studentIDs}
+	for _, a := range fields {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListByStudentIDs", varargs...)
+	ret0, _ := ret[0].(entity.StudentSubjects)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListByStudentIDs indicates an expected call of ListByStudentIDs.
+func (mr *MockStudentSubjectMockRecorder) ListByStudentIDs(ctx, studentIDs interface{}, fields ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, studentIDs}, fields...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByStudentIDs", reflect.TypeOf((*MockStudentSubject)(nil).ListByStudentIDs), varargs...)
+}
+
+// Replace mocks base method.
+func (m *MockStudentSubject) Replace(ctx context.Context, schoolType entity.SchoolType, subjects entity.StudentSubjects) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Replace", ctx, schoolType, subjects)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Replace indicates an expected call of Replace.
+func (mr *MockStudentSubjectMockRecorder) Replace(ctx, schoolType, subjects interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Replace", reflect.TypeOf((*MockStudentSubject)(nil).Replace), ctx, schoolType, subjects)
+}
+
 // MockSchedule is a mock of Schedule interface.
 type MockSchedule struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
生徒の受講科目管理テーブルの操作インターフェースを実装しました

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
