### PR TITLE
feat(gateway): add fields to shifts response

### DIFF
--- a/api/internal/gateway/entity/teacher.go
+++ b/api/internal/gateway/entity/teacher.go
@@ -25,3 +25,11 @@ func NewTeachers(teachers []*user.Teacher) Teachers {
 	}
 	return ts
 }
+
+func (ts Teachers) IDs() []string {
+	ids := make([]string, len(ts))
+	for i := range ts {
+		ids[i] = ts[i].Id
+	}
+	return ids
+}

--- a/api/internal/gateway/entity/teacher_shift.go
+++ b/api/internal/gateway/entity/teacher_shift.go
@@ -29,3 +29,14 @@ func (ss TeacherShifts) MapByShiftID() map[int64]*TeacherShift {
 	}
 	return res
 }
+
+func (ss TeacherShifts) GroupByTeacherID() map[string]TeacherShifts {
+	res := make(map[string]TeacherShifts, 0)
+	for _, s := range ss {
+		if _, ok := res[s.TeacherId]; !ok {
+			res[s.TeacherId] = make(TeacherShifts, 0)
+		}
+		res[s.TeacherId] = append(res[s.TeacherId], s)
+	}
+	return res
+}

--- a/api/internal/gateway/entity/teacher_shift.go
+++ b/api/internal/gateway/entity/teacher_shift.go
@@ -34,7 +34,7 @@ func (ss TeacherShifts) GroupByTeacherID() map[string]TeacherShifts {
 	res := make(map[string]TeacherShifts)
 	for _, s := range ss {
 		if _, ok := res[s.TeacherId]; !ok {
-			res[s.TeacherId] = make(TeacherShifts)
+			res[s.TeacherId] = make(TeacherShifts, 0)
 		}
 		res[s.TeacherId] = append(res[s.TeacherId], s)
 	}

--- a/api/internal/gateway/entity/teacher_shift.go
+++ b/api/internal/gateway/entity/teacher_shift.go
@@ -31,10 +31,10 @@ func (ss TeacherShifts) MapByShiftID() map[int64]*TeacherShift {
 }
 
 func (ss TeacherShifts) GroupByTeacherID() map[string]TeacherShifts {
-	res := make(map[string]TeacherShifts, 0)
+	res := make(map[string]TeacherShifts)
 	for _, s := range ss {
 		if _, ok := res[s.TeacherId]; !ok {
-			res[s.TeacherId] = make(TeacherShifts, 0)
+			res[s.TeacherId] = make(TeacherShifts)
 		}
 		res[s.TeacherId] = append(res[s.TeacherId], s)
 	}

--- a/api/internal/gateway/teacher/v1/entity/teacher_submission.go
+++ b/api/internal/gateway/teacher/v1/entity/teacher_submission.go
@@ -8,7 +8,7 @@ import (
 )
 
 type TeacherSubmission struct {
-	ID               int64                   `json:"id"`               // シフト募集ID
+	ShiftSummaryID   int64                   `json:"id"`               // シフト募集ID
 	Year             int32                   `json:"year"`             // 年
 	Month            int32                   `json:"month"`            // 月
 	ShiftStatus      ShiftStatus             `json:"shiftStatus"`      // シフト募集ステータス
@@ -21,6 +21,13 @@ type TeacherSubmission struct {
 
 type TeacherSubmissions []*TeacherSubmission
 
+type TeacherSubmissionDetail struct {
+	Teacher     *Teacher `json:"teacher"`     // 講師情報
+	LessonTotal int64    `json:"lessonTotal"` // 登録担当授業数
+}
+
+type TeacherSubmissionDetails []*TeacherSubmissionDetail
+
 type TeacherSubmissionStatus int32
 
 const (
@@ -31,7 +38,7 @@ const (
 
 func NewTeacherSubmission(summary *entity.ShiftSummary, submission *entity.TeacherSubmission) *TeacherSubmission {
 	return &TeacherSubmission{
-		ID:               summary.Id,
+		ShiftSummaryID:   summary.Id,
 		Year:             summary.YearMonth / 100,
 		Month:            summary.YearMonth % 100,
 		ShiftStatus:      NewShiftStatus(summary.Status),
@@ -50,6 +57,24 @@ func NewTeacherSubmissions(
 	for i, s := range summaries {
 		submission := submissions[s.Id] // null: 出勤不可
 		ss[i] = NewTeacherSubmission(s, submission)
+	}
+	return ss
+}
+
+func NewTeacherSubmissionDetail(teacher *entity.Teacher, shifts entity.TeacherShifts) *TeacherSubmissionDetail {
+	return &TeacherSubmissionDetail{
+		Teacher:     NewTeacher(teacher),
+		LessonTotal: int64(len(shifts)),
+	}
+}
+
+func NewTeacherSubmissionDetails(
+	teachers entity.Teachers, shiftsMap map[string]entity.TeacherShifts,
+) TeacherSubmissionDetails {
+	ss := make(TeacherSubmissionDetails, len(teachers))
+	for i, teacher := range teachers {
+		shifts := shiftsMap[teacher.Id]
+		ss[i] = NewTeacherSubmissionDetail(teacher, shifts)
 	}
 	return ss
 }

--- a/api/internal/gateway/teacher/v1/entity/teacher_submission_test.go
+++ b/api/internal/gateway/teacher/v1/entity/teacher_submission_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/calmato/shs-web/api/internal/gateway/entity"
 	"github.com/calmato/shs-web/api/pkg/jst"
 	"github.com/calmato/shs-web/api/proto/lesson"
+	"github.com/calmato/shs-web/api/proto/user"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -41,7 +42,7 @@ func TestTeacherSubmission(t *testing.T) {
 				},
 			},
 			expect: &TeacherSubmission{
-				ID:               1,
+				ShiftSummaryID:   1,
 				Year:             2022,
 				Month:            1,
 				ShiftStatus:      ShiftStatusAccepting,
@@ -111,7 +112,7 @@ func TestTeacherSubmissions(t *testing.T) {
 			},
 			expect: TeacherSubmissions{
 				{
-					ID:               1,
+					ShiftSummaryID:   1,
 					Year:             2022,
 					Month:            1,
 					ShiftStatus:      ShiftStatusAccepting,
@@ -122,7 +123,7 @@ func TestTeacherSubmissions(t *testing.T) {
 					UpdatedAt:        now,
 				},
 				{
-					ID:               2,
+					ShiftSummaryID:   2,
 					Year:             2022,
 					Month:            2,
 					ShiftStatus:      ShiftStatusWaiting,
@@ -141,6 +142,179 @@ func TestTeacherSubmissions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, tt.expect, NewTeacherSubmissions(tt.summaries, tt.submissions))
+		})
+	}
+}
+
+func TestTeacherSubmissionDetail(t *testing.T) {
+	t.Parallel()
+	now := jst.Date(2021, 8, 2, 18, 30, 0, 0)
+	tests := []struct {
+		name    string
+		teacher *entity.Teacher
+		shifts  entity.TeacherShifts
+		expect  *TeacherSubmissionDetail
+	}{
+		{
+			name: "success",
+			teacher: &entity.Teacher{
+				Teacher: &user.Teacher{
+					Id:            "kSByoE6FetnPs5Byk3a9Zx",
+					LastName:      "中村",
+					FirstName:     "広大",
+					LastNameKana:  "なかむら",
+					FirstNameKana: "こうだい",
+					Mail:          "teacher-test001@calmato.jp",
+					Role:          user.Role_ROLE_TEACHER,
+					CreatedAt:     now.Unix(),
+					UpdatedAt:     now.Unix(),
+				},
+			},
+			shifts: entity.TeacherShifts{
+				{
+					TeacherShift: &lesson.TeacherShift{
+						TeacherId:      "kSByoE6FetnPs5Byk3a9Zx",
+						ShiftId:        1,
+						ShiftSummaryId: 1,
+						CreatedAt:      now.Unix(),
+						UpdatedAt:      now.Unix(),
+					},
+				},
+				{
+					TeacherShift: &lesson.TeacherShift{
+						TeacherId:      "kSByoE6FetnPs5Byk3a9Zx",
+						ShiftId:        3,
+						ShiftSummaryId: 1,
+						CreatedAt:      now.Unix(),
+						UpdatedAt:      now.Unix(),
+					},
+				},
+			},
+			expect: &TeacherSubmissionDetail{
+				Teacher: &Teacher{
+					ID:            "kSByoE6FetnPs5Byk3a9Zx",
+					LastName:      "中村",
+					FirstName:     "広大",
+					LastNameKana:  "なかむら",
+					FirstNameKana: "こうだい",
+					Mail:          "teacher-test001@calmato.jp",
+					Role:          RoleTeacher,
+					CreatedAt:     now,
+					UpdatedAt:     now,
+				},
+				LessonTotal: 2,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, NewTeacherSubmissionDetail(tt.teacher, tt.shifts))
+		})
+	}
+}
+
+func TestTeacherSubmissionDetails(t *testing.T) {
+	t.Parallel()
+	now := jst.Date(2021, 8, 2, 18, 30, 0, 0)
+	tests := []struct {
+		name     string
+		teachers entity.Teachers
+		shifts   map[string]entity.TeacherShifts
+		expect   TeacherSubmissionDetails
+	}{
+		{
+			name: "success",
+			teachers: entity.Teachers{
+				{
+					Teacher: &user.Teacher{
+						Id:            "kSByoE6FetnPs5Byk3a9Zx",
+						LastName:      "中村",
+						FirstName:     "広大",
+						LastNameKana:  "なかむら",
+						FirstNameKana: "こうだい",
+						Mail:          "teacher-test001@calmato.jp",
+						Role:          user.Role_ROLE_TEACHER,
+						CreatedAt:     now.Unix(),
+						UpdatedAt:     now.Unix(),
+					},
+				},
+				{
+					Teacher: &user.Teacher{
+						Id:            "teacherid",
+						LastName:      "テスト",
+						FirstName:     "講師",
+						LastNameKana:  "てすと",
+						FirstNameKana: "こうし",
+						Mail:          "teacher-test002@calmato.jp",
+						Role:          user.Role_ROLE_ADMINISTRATOR,
+						CreatedAt:     now.Unix(),
+						UpdatedAt:     now.Unix(),
+					},
+				},
+			},
+			shifts: map[string]entity.TeacherShifts{
+				"kSByoE6FetnPs5Byk3a9Zx": {
+					{
+						TeacherShift: &lesson.TeacherShift{
+							TeacherId:      "kSByoE6FetnPs5Byk3a9Zx",
+							ShiftId:        1,
+							ShiftSummaryId: 1,
+							CreatedAt:      now.Unix(),
+							UpdatedAt:      now.Unix(),
+						},
+					},
+					{
+						TeacherShift: &lesson.TeacherShift{
+							TeacherId:      "kSByoE6FetnPs5Byk3a9Zx",
+							ShiftId:        3,
+							ShiftSummaryId: 1,
+							CreatedAt:      now.Unix(),
+							UpdatedAt:      now.Unix(),
+						},
+					},
+				},
+			},
+			expect: TeacherSubmissionDetails{
+				{
+					Teacher: &Teacher{
+						ID:            "kSByoE6FetnPs5Byk3a9Zx",
+						LastName:      "中村",
+						FirstName:     "広大",
+						LastNameKana:  "なかむら",
+						FirstNameKana: "こうだい",
+						Mail:          "teacher-test001@calmato.jp",
+						Role:          RoleTeacher,
+						CreatedAt:     now,
+						UpdatedAt:     now,
+					},
+					LessonTotal: 2,
+				},
+				{
+					Teacher: &Teacher{
+						ID:            "teacherid",
+						LastName:      "テスト",
+						FirstName:     "講師",
+						LastNameKana:  "てすと",
+						FirstNameKana: "こうし",
+						Mail:          "teacher-test002@calmato.jp",
+						Role:          RoleAdministrator,
+						CreatedAt:     now,
+						UpdatedAt:     now,
+					},
+					LessonTotal: 0,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, NewTeacherSubmissionDetails(tt.teachers, tt.shifts))
 		})
 	}
 }

--- a/api/internal/gateway/teacher/v1/handler/teacher_shift.go
+++ b/api/internal/gateway/teacher/v1/handler/teacher_shift.go
@@ -98,11 +98,11 @@ func (h *apiV1Handler) ListTeacherShifts(ctx *gin.Context) {
 	var submission *gentity.TeacherSubmission
 	var teacherShifts gentity.TeacherShifts
 	eg.Go(func() error {
-		in := &lesson.ListTeacherShiftsRequest{
+		in := &lesson.GetTeacherShiftsRequest{
 			TeacherId:      teacherID,
 			ShiftSummaryId: shiftSummaryID,
 		}
-		out, err := h.lesson.ListTeacherShifts(ectx, in)
+		out, err := h.lesson.GetTeacherShifts(ectx, in)
 		if err != nil {
 			return err
 		}

--- a/api/internal/gateway/teacher/v1/handler/teacher_shift_test.go
+++ b/api/internal/gateway/teacher/v1/handler/teacher_shift_test.go
@@ -83,7 +83,7 @@ func TestListTeacherSubmissions(t *testing.T) {
 				body: &response.TeacherSubmissionsResponse{
 					Summaries: entity.TeacherSubmissions{
 						{
-							ID:               1,
+							ShiftSummaryID:   1,
 							Year:             2022,
 							Month:            2,
 							ShiftStatus:      entity.ShiftStatusAccepting,
@@ -94,7 +94,7 @@ func TestListTeacherSubmissions(t *testing.T) {
 							UpdatedAt:        now,
 						},
 						{
-							ID:               2,
+							ShiftSummaryID:   2,
 							Year:             2022,
 							Month:            3,
 							ShiftStatus:      entity.ShiftStatusWaiting,
@@ -269,17 +269,17 @@ func TestListTeacherShifts(t *testing.T) {
 				summaryOut := &lesson.GetShiftSummaryResponse{Summary: summary}
 				shiftsIn := &lesson.ListShiftsRequest{ShiftSummaryId: 1}
 				shiftsOut := &lesson.ListShiftsResponse{Shifts: shifts}
-				teacherIn := &lesson.ListTeacherShiftsRequest{
+				teacherIn := &lesson.GetTeacherShiftsRequest{
 					TeacherId:      idmock,
 					ShiftSummaryId: 1,
 				}
-				teacherOut := &lesson.ListTeacherShiftsResponse{
+				teacherOut := &lesson.GetTeacherShiftsResponse{
 					Submission: submission,
 					Shifts:     teacherShifts,
 				}
 				mocks.lesson.EXPECT().GetShiftSummary(gomock.Any(), summaryIn).Return(summaryOut, nil)
 				mocks.lesson.EXPECT().ListShifts(gomock.Any(), shiftsIn).Return(shiftsOut, nil)
-				mocks.lesson.EXPECT().ListTeacherShifts(gomock.Any(), teacherIn).Return(teacherOut, nil)
+				mocks.lesson.EXPECT().GetTeacherShifts(gomock.Any(), teacherIn).Return(teacherOut, nil)
 			},
 			teacherID: idmock,
 			summaryID: "1",
@@ -287,7 +287,7 @@ func TestListTeacherShifts(t *testing.T) {
 				code: http.StatusOK,
 				body: &response.TeacherShiftsResponse{
 					Summary: &entity.TeacherSubmission{
-						ID:               1,
+						ShiftSummaryID:   1,
 						Year:             2022,
 						Month:            2,
 						ShiftStatus:      entity.ShiftStatusAccepting,
@@ -369,17 +369,17 @@ func TestListTeacherShifts(t *testing.T) {
 				summaryIn := &lesson.GetShiftSummaryRequest{Id: 1}
 				shiftsIn := &lesson.ListShiftsRequest{ShiftSummaryId: 1}
 				shiftsOut := &lesson.ListShiftsResponse{Shifts: shifts}
-				teacherIn := &lesson.ListTeacherShiftsRequest{
+				teacherIn := &lesson.GetTeacherShiftsRequest{
 					TeacherId:      idmock,
 					ShiftSummaryId: 1,
 				}
-				teacherOut := &lesson.ListTeacherShiftsResponse{
+				teacherOut := &lesson.GetTeacherShiftsResponse{
 					Submission: submission,
 					Shifts:     teacherShifts,
 				}
 				mocks.lesson.EXPECT().GetShiftSummary(gomock.Any(), summaryIn).Return(nil, errmock)
 				mocks.lesson.EXPECT().ListShifts(gomock.Any(), shiftsIn).Return(shiftsOut, nil)
-				mocks.lesson.EXPECT().ListTeacherShifts(gomock.Any(), teacherIn).Return(teacherOut, nil)
+				mocks.lesson.EXPECT().GetTeacherShifts(gomock.Any(), teacherIn).Return(teacherOut, nil)
 			},
 			teacherID: idmock,
 			summaryID: "1",
@@ -393,17 +393,17 @@ func TestListTeacherShifts(t *testing.T) {
 				summaryIn := &lesson.GetShiftSummaryRequest{Id: 1}
 				summaryOut := &lesson.GetShiftSummaryResponse{Summary: summary}
 				shiftsIn := &lesson.ListShiftsRequest{ShiftSummaryId: 1}
-				teacherIn := &lesson.ListTeacherShiftsRequest{
+				teacherIn := &lesson.GetTeacherShiftsRequest{
 					TeacherId:      idmock,
 					ShiftSummaryId: 1,
 				}
-				teacherOut := &lesson.ListTeacherShiftsResponse{
+				teacherOut := &lesson.GetTeacherShiftsResponse{
 					Submission: submission,
 					Shifts:     teacherShifts,
 				}
 				mocks.lesson.EXPECT().GetShiftSummary(gomock.Any(), summaryIn).Return(summaryOut, nil)
 				mocks.lesson.EXPECT().ListShifts(gomock.Any(), shiftsIn).Return(nil, errmock)
-				mocks.lesson.EXPECT().ListTeacherShifts(gomock.Any(), teacherIn).Return(teacherOut, nil)
+				mocks.lesson.EXPECT().GetTeacherShifts(gomock.Any(), teacherIn).Return(teacherOut, nil)
 			},
 			teacherID: idmock,
 			summaryID: "1",
@@ -418,13 +418,13 @@ func TestListTeacherShifts(t *testing.T) {
 				summaryOut := &lesson.GetShiftSummaryResponse{Summary: summary}
 				shiftsIn := &lesson.ListShiftsRequest{ShiftSummaryId: 1}
 				shiftsOut := &lesson.ListShiftsResponse{Shifts: shifts}
-				teacherIn := &lesson.ListTeacherShiftsRequest{
+				teacherIn := &lesson.GetTeacherShiftsRequest{
 					TeacherId:      idmock,
 					ShiftSummaryId: 1,
 				}
 				mocks.lesson.EXPECT().GetShiftSummary(gomock.Any(), summaryIn).Return(summaryOut, nil)
 				mocks.lesson.EXPECT().ListShifts(gomock.Any(), shiftsIn).Return(shiftsOut, nil)
-				mocks.lesson.EXPECT().ListTeacherShifts(gomock.Any(), teacherIn).Return(nil, errmock)
+				mocks.lesson.EXPECT().GetTeacherShifts(gomock.Any(), teacherIn).Return(nil, errmock)
 			},
 			teacherID: idmock,
 			summaryID: "1",
@@ -441,17 +441,17 @@ func TestListTeacherShifts(t *testing.T) {
 				shiftsOut := &lesson.ListShiftsResponse{
 					Shifts: []*lesson.Shift{{Date: "20220200"}},
 				}
-				teacherIn := &lesson.ListTeacherShiftsRequest{
+				teacherIn := &lesson.GetTeacherShiftsRequest{
 					TeacherId:      idmock,
 					ShiftSummaryId: 1,
 				}
-				teacherOut := &lesson.ListTeacherShiftsResponse{
+				teacherOut := &lesson.GetTeacherShiftsResponse{
 					Submission: submission,
 					Shifts:     teacherShifts,
 				}
 				mocks.lesson.EXPECT().GetShiftSummary(gomock.Any(), summaryIn).Return(summaryOut, nil)
 				mocks.lesson.EXPECT().ListShifts(gomock.Any(), shiftsIn).Return(shiftsOut, nil)
-				mocks.lesson.EXPECT().ListTeacherShifts(gomock.Any(), teacherIn).Return(teacherOut, nil)
+				mocks.lesson.EXPECT().GetTeacherShifts(gomock.Any(), teacherIn).Return(teacherOut, nil)
 			},
 			teacherID: idmock,
 			summaryID: "1",
@@ -575,7 +575,7 @@ func TestUpsertTeacherShifts(t *testing.T) {
 				code: http.StatusOK,
 				body: &response.TeacherShiftsResponse{
 					Summary: &entity.TeacherSubmission{
-						ID:               1,
+						ShiftSummaryID:   1,
 						Year:             2022,
 						Month:            2,
 						ShiftStatus:      entity.ShiftStatusAccepting,

--- a/api/internal/gateway/teacher/v1/response/shift.go
+++ b/api/internal/gateway/teacher/v1/response/shift.go
@@ -7,6 +7,7 @@ type ShiftSummariesResponse struct {
 }
 
 type ShiftsResponse struct {
-	Summary *entity.ShiftSummary `json:"summary"` // シフト募集概要
-	Shifts  entity.ShiftDetails  `json:"shifts"`  // 募集シフト一覧
+	Summary  *entity.ShiftSummary            `json:"summary"`  // シフト募集概要
+	Shifts   entity.ShiftDetails             `json:"shifts"`   // 募集シフト一覧
+	Teachers entity.TeacherSubmissionDetails `json:"teachers"` // 講師情報一覧
 }

--- a/api/internal/lesson/api/teacher_shift_test.go
+++ b/api/internal/lesson/api/teacher_shift_test.go
@@ -108,13 +108,8 @@ func TestListTeacherSubmissionsByShiftSummaryID(t *testing.T) {
 func TestListTeacherShifts(t *testing.T) {
 	t.Parallel()
 	req := &lesson.ListTeacherShiftsRequest{
-		TeacherId:      "teacherid",
+		TeacherIds:     []string{"teacherid1", "teacherid2"},
 		ShiftSummaryId: 1,
-	}
-	submission := &entity.TeacherSubmission{
-		TeacherID:      "teacherid",
-		ShiftSummaryID: 1,
-		Decided:        true,
 	}
 	shifts := entity.TeacherShifts{
 		{
@@ -139,20 +134,12 @@ func TestListTeacherShifts(t *testing.T) {
 			name: "success",
 			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
 				mocks.validator.EXPECT().ListTeacherShifts(req).Return(nil)
-				mocks.db.TeacherSubmission.EXPECT().Get(gomock.Any(), "teacherid", int64(1)).Return(submission, nil)
-				mocks.db.TeacherShift.EXPECT().ListByShiftSummaryID(gomock.Any(), "teacherid", int64(1)).Return(shifts, nil)
+				mocks.db.TeacherShift.EXPECT().ListByShiftSummaryID(ctx, []string{"teacherid1", "teacherid2"}, int64(1)).Return(shifts, nil)
 			},
 			req: req,
 			expect: &testResponse{
 				code: codes.OK,
 				body: &lesson.ListTeacherShiftsResponse{
-					Submission: &lesson.TeacherSubmission{
-						TeacherId:      "teacherid",
-						ShiftSummaryId: 1,
-						Decided:        true,
-						CreatedAt:      time.Time{}.Unix(),
-						UpdatedAt:      time.Time{}.Unix(),
-					},
 					Shifts: []*lesson.TeacherShift{
 						{
 							TeacherId:      "teacherid",
@@ -184,23 +171,10 @@ func TestListTeacherShifts(t *testing.T) {
 			},
 		},
 		{
-			name: "failed to get submission",
-			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
-				mocks.validator.EXPECT().ListTeacherShifts(req).Return(nil)
-				mocks.db.TeacherSubmission.EXPECT().Get(gomock.Any(), "teacherid", int64(1)).Return(nil, errmock)
-				mocks.db.TeacherShift.EXPECT().ListByShiftSummaryID(gomock.Any(), "teacherid", int64(1)).Return(shifts, nil)
-			},
-			req: req,
-			expect: &testResponse{
-				code: codes.Internal,
-			},
-		},
-		{
 			name: "failed to list shifts",
 			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
 				mocks.validator.EXPECT().ListTeacherShifts(req).Return(nil)
-				mocks.db.TeacherSubmission.EXPECT().Get(gomock.Any(), "teacherid", int64(1)).Return(submission, nil)
-				mocks.db.TeacherShift.EXPECT().ListByShiftSummaryID(gomock.Any(), "teacherid", int64(1)).Return(nil, errmock)
+				mocks.db.TeacherShift.EXPECT().ListByShiftSummaryID(ctx, []string{"teacherid1", "teacherid2"}, int64(1)).Return(nil, errmock)
 			},
 			req: req,
 			expect: &testResponse{
@@ -213,6 +187,118 @@ func TestListTeacherShifts(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, testGRPC(tt.setup, tt.expect, func(ctx context.Context, service *lessonService) (proto.Message, error) {
 			return service.ListTeacherShifts(ctx, tt.req)
+		}))
+	}
+}
+
+func TestGetTeacherShifts(t *testing.T) {
+	t.Parallel()
+	req := &lesson.GetTeacherShiftsRequest{
+		TeacherId:      "teacherid",
+		ShiftSummaryId: 1,
+	}
+	submission := &entity.TeacherSubmission{
+		TeacherID:      "teacherid",
+		ShiftSummaryID: 1,
+		Decided:        true,
+	}
+	shifts := entity.TeacherShifts{
+		{
+			TeacherID:      "teacherid",
+			ShiftID:        1,
+			ShiftSummaryID: 1,
+		},
+		{
+			TeacherID:      "teacherid",
+			ShiftID:        2,
+			ShiftSummaryID: 1,
+		},
+	}
+
+	tests := []struct {
+		name   string
+		setup  func(ctx context.Context, t *testing.T, mocks *mocks)
+		req    *lesson.GetTeacherShiftsRequest
+		expect *testResponse
+	}{
+		{
+			name: "success",
+			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
+				mocks.validator.EXPECT().GetTeacherShifts(req).Return(nil)
+				mocks.db.TeacherSubmission.EXPECT().Get(gomock.Any(), "teacherid", int64(1)).Return(submission, nil)
+				mocks.db.TeacherShift.EXPECT().ListByShiftSummaryID(gomock.Any(), []string{"teacherid"}, int64(1)).Return(shifts, nil)
+			},
+			req: req,
+			expect: &testResponse{
+				code: codes.OK,
+				body: &lesson.GetTeacherShiftsResponse{
+					Submission: &lesson.TeacherSubmission{
+						TeacherId:      "teacherid",
+						ShiftSummaryId: 1,
+						Decided:        true,
+						CreatedAt:      time.Time{}.Unix(),
+						UpdatedAt:      time.Time{}.Unix(),
+					},
+					Shifts: []*lesson.TeacherShift{
+						{
+							TeacherId:      "teacherid",
+							ShiftSummaryId: 1,
+							ShiftId:        1,
+							CreatedAt:      time.Time{}.Unix(),
+							UpdatedAt:      time.Time{}.Unix(),
+						},
+						{
+							TeacherId:      "teacherid",
+							ShiftSummaryId: 1,
+							ShiftId:        2,
+							CreatedAt:      time.Time{}.Unix(),
+							UpdatedAt:      time.Time{}.Unix(),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "invliad argument",
+			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
+				req := &lesson.GetTeacherShiftsRequest{}
+				mocks.validator.EXPECT().GetTeacherShifts(req).Return(validation.ErrRequestValidation)
+			},
+			req: &lesson.GetTeacherShiftsRequest{},
+			expect: &testResponse{
+				code: codes.InvalidArgument,
+			},
+		},
+		{
+			name: "failed to get submission",
+			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
+				mocks.validator.EXPECT().GetTeacherShifts(req).Return(nil)
+				mocks.db.TeacherSubmission.EXPECT().Get(gomock.Any(), "teacherid", int64(1)).Return(nil, errmock)
+				mocks.db.TeacherShift.EXPECT().ListByShiftSummaryID(gomock.Any(), []string{"teacherid"}, int64(1)).Return(shifts, nil)
+			},
+			req: req,
+			expect: &testResponse{
+				code: codes.Internal,
+			},
+		},
+		{
+			name: "failed to list shifts",
+			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
+				mocks.validator.EXPECT().GetTeacherShifts(req).Return(nil)
+				mocks.db.TeacherSubmission.EXPECT().Get(gomock.Any(), "teacherid", int64(1)).Return(submission, nil)
+				mocks.db.TeacherShift.EXPECT().ListByShiftSummaryID(gomock.Any(), []string{"teacherid"}, int64(1)).Return(nil, errmock)
+			},
+			req: req,
+			expect: &testResponse{
+				code: codes.Internal,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, testGRPC(tt.setup, tt.expect, func(ctx context.Context, service *lessonService) (proto.Message, error) {
+			return service.GetTeacherShifts(ctx, tt.req)
 		}))
 	}
 }

--- a/api/internal/lesson/database/database.go
+++ b/api/internal/lesson/database/database.go
@@ -69,7 +69,7 @@ type TeacherSubmission interface {
 
 type TeacherShift interface {
 	ListByShiftSummaryID(
-		ctx context.Context, teacherID string, summaryID int64, fields ...string,
+		ctx context.Context, teacherIDs []string, summaryID int64, fields ...string,
 	) (entity.TeacherShifts, error)
 	Replace(ctx context.Context, submission *entity.TeacherSubmission, shifts entity.TeacherShifts) error
 }

--- a/api/internal/lesson/database/teacher_shift.go
+++ b/api/internal/lesson/database/teacher_shift.go
@@ -31,7 +31,7 @@ func NewTeacherShift(db *database.Client) TeacherShift {
 }
 
 func (s *teacherShift) ListByShiftSummaryID(
-	ctx context.Context, teacherID string, summaryID int64, fields ...string,
+	ctx context.Context, teacherIDs []string, summaryID int64, fields ...string,
 ) (entity.TeacherShifts, error) {
 	var shifts entity.TeacherShifts
 	if len(fields) == 0 {
@@ -39,7 +39,7 @@ func (s *teacherShift) ListByShiftSummaryID(
 	}
 
 	stmt := s.db.DB.Table(teacherShiftTable).Select(fields).
-		Where("teacher_id = ?", teacherID).
+		Where("teacher_id IN (?)", teacherIDs).
 		Where("shift_summary_id = ?", summaryID)
 
 	err := stmt.Find(&shifts).Error

--- a/api/internal/lesson/database/teacher_shift_test.go
+++ b/api/internal/lesson/database/teacher_shift_test.go
@@ -48,8 +48,8 @@ func TestTeacherShift_ListByShiftSummaryID(t *testing.T) {
 	require.NoError(t, err)
 
 	type args struct {
-		teacherID string
-		summaryID int64
+		teacherIDs []string
+		summaryID  int64
 	}
 	type want struct {
 		shifts entity.TeacherShifts
@@ -65,8 +65,8 @@ func TestTeacherShift_ListByShiftSummaryID(t *testing.T) {
 			name:  "success",
 			setup: func(ctx context.Context, t *testing.T, m *mocks) {},
 			args: args{
-				teacherID: teacherID,
-				summaryID: 1,
+				teacherIDs: []string{teacherID},
+				summaryID:  1,
 			},
 			want: want{
 				shifts: teacherShifts,
@@ -85,7 +85,7 @@ func TestTeacherShift_ListByShiftSummaryID(t *testing.T) {
 			tt.setup(ctx, t, m)
 
 			db := NewTeacherShift(m.db)
-			actual, err := db.ListByShiftSummaryID(ctx, tt.args.teacherID, tt.args.summaryID)
+			actual, err := db.ListByShiftSummaryID(ctx, tt.args.teacherIDs, tt.args.summaryID)
 			assert.Equal(t, tt.want.isErr, err != nil, err)
 			assert.Len(t, actual, len(tt.want.shifts))
 			for i, shift := range tt.want.shifts {

--- a/api/internal/lesson/validation/teacher_shift.go
+++ b/api/internal/lesson/validation/teacher_shift.go
@@ -22,6 +22,15 @@ func (v *requestValidation) ListTeacherShifts(req *lesson.ListTeacherShiftsReque
 	return nil
 }
 
+func (v *requestValidation) GetTeacherShifts(req *lesson.GetTeacherShiftsRequest) error {
+	if err := req.Validate(); err != nil {
+		validate := err.(lesson.GetTeacherShiftsRequestValidationError)
+		return validationError(validate.Error())
+	}
+
+	return nil
+}
+
 func (v *requestValidation) UpsertTeacherShifts(req *lesson.UpsertTeacherShiftsRequest) error {
 	if err := req.Validate(); err != nil {
 		validate := err.(lesson.UpsertTeacherShiftsRequestValidationError)

--- a/api/internal/lesson/validation/teacher_shift_test.go
+++ b/api/internal/lesson/validation/teacher_shift_test.go
@@ -72,15 +72,23 @@ func TestListTeacherShifts(t *testing.T) {
 		{
 			name: "success",
 			req: &lesson.ListTeacherShiftsRequest{
-				TeacherId:      "teacherid",
+				TeacherIds:     []string{"teacherid"},
 				ShiftSummaryId: 1,
 			},
 			isErr: false,
 		},
 		{
-			name: "TeacherId is min_len",
+			name: "TeacherIds is unique",
 			req: &lesson.ListTeacherShiftsRequest{
-				TeacherId:      "",
+				TeacherIds:     []string{"teacherid", "teacherid"},
+				ShiftSummaryId: 1,
+			},
+			isErr: true,
+		},
+		{
+			name: "TeacherIds is items.min_len",
+			req: &lesson.ListTeacherShiftsRequest{
+				TeacherIds:     []string{""},
 				ShiftSummaryId: 1,
 			},
 			isErr: true,
@@ -88,7 +96,7 @@ func TestListTeacherShifts(t *testing.T) {
 		{
 			name: "ShiftSummaryId is gt",
 			req: &lesson.ListTeacherShiftsRequest{
-				TeacherId:      "teacherid",
+				TeacherIds:     []string{"teacherid"},
 				ShiftSummaryId: 0,
 			},
 			isErr: true,
@@ -100,6 +108,51 @@ func TestListTeacherShifts(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			err := validator.ListTeacherShifts(tt.req)
+			assert.Equal(t, tt.isErr, err != nil, err)
+		})
+	}
+}
+
+func TestGetTeacherShifts(t *testing.T) {
+	t.Parallel()
+	validator := NewRequestValidation()
+
+	tests := []struct {
+		name  string
+		req   *lesson.GetTeacherShiftsRequest
+		isErr bool
+	}{
+		{
+			name: "success",
+			req: &lesson.GetTeacherShiftsRequest{
+				TeacherId:      "teacherid",
+				ShiftSummaryId: 1,
+			},
+			isErr: false,
+		},
+		{
+			name: "TeacherId is min_len",
+			req: &lesson.GetTeacherShiftsRequest{
+				TeacherId:      "",
+				ShiftSummaryId: 1,
+			},
+			isErr: true,
+		},
+		{
+			name: "ShiftSummaryId is gt",
+			req: &lesson.GetTeacherShiftsRequest{
+				TeacherId:      "teacherid",
+				ShiftSummaryId: 0,
+			},
+			isErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validator.GetTeacherShifts(tt.req)
 			assert.Equal(t, tt.isErr, err != nil, err)
 		})
 	}

--- a/api/internal/lesson/validation/validator.go
+++ b/api/internal/lesson/validation/validator.go
@@ -20,6 +20,7 @@ type RequestValidation interface {
 	CreateShifts(req *lesson.CreateShiftsRequest) error
 	ListTeacherSubmissionsByShiftSummaryIDs(req *lesson.ListTeacherSubmissionsByShiftSummaryIDsRequest) error
 	ListTeacherShifts(req *lesson.ListTeacherShiftsRequest) error
+	GetTeacherShifts(req *lesson.GetTeacherShiftsRequest) error
 	UpsertTeacherShifts(req *lesson.UpsertTeacherShiftsRequest) error
 }
 

--- a/api/mock/lesson/database/database.go
+++ b/api/mock/lesson/database/database.go
@@ -284,9 +284,9 @@ func (m *MockTeacherShift) EXPECT() *MockTeacherShiftMockRecorder {
 }
 
 // ListByShiftSummaryID mocks base method.
-func (m *MockTeacherShift) ListByShiftSummaryID(ctx context.Context, teacherID string, summaryID int64, fields ...string) (entity.TeacherShifts, error) {
+func (m *MockTeacherShift) ListByShiftSummaryID(ctx context.Context, teacherIDs []string, summaryID int64, fields ...string) (entity.TeacherShifts, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, teacherID, summaryID}
+	varargs := []interface{}{ctx, teacherIDs, summaryID}
 	for _, a := range fields {
 		varargs = append(varargs, a)
 	}
@@ -297,9 +297,9 @@ func (m *MockTeacherShift) ListByShiftSummaryID(ctx context.Context, teacherID s
 }
 
 // ListByShiftSummaryID indicates an expected call of ListByShiftSummaryID.
-func (mr *MockTeacherShiftMockRecorder) ListByShiftSummaryID(ctx, teacherID, summaryID interface{}, fields ...interface{}) *gomock.Call {
+func (mr *MockTeacherShiftMockRecorder) ListByShiftSummaryID(ctx, teacherIDs, summaryID interface{}, fields ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, teacherID, summaryID}, fields...)
+	varargs := append([]interface{}{ctx, teacherIDs, summaryID}, fields...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByShiftSummaryID", reflect.TypeOf((*MockTeacherShift)(nil).ListByShiftSummaryID), varargs...)
 }
 

--- a/api/mock/lesson/validation/validator.go
+++ b/api/mock/lesson/validation/validator.go
@@ -76,6 +76,20 @@ func (mr *MockRequestValidationMockRecorder) GetShiftSummary(req interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShiftSummary", reflect.TypeOf((*MockRequestValidation)(nil).GetShiftSummary), req)
 }
 
+// GetTeacherShifts mocks base method.
+func (m *MockRequestValidation) GetTeacherShifts(req *lesson.GetTeacherShiftsRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTeacherShifts", req)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GetTeacherShifts indicates an expected call of GetTeacherShifts.
+func (mr *MockRequestValidationMockRecorder) GetTeacherShifts(req interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeacherShifts", reflect.TypeOf((*MockRequestValidation)(nil).GetTeacherShifts), req)
+}
+
 // ListShiftSummaries mocks base method.
 func (m *MockRequestValidation) ListShiftSummaries(req *lesson.ListShiftSummariesRequest) error {
 	m.ctrl.T.Helper()

--- a/api/mock/proto/lesson/service_grpc.pb.go.go
+++ b/api/mock/proto/lesson/service_grpc.pb.go.go
@@ -96,6 +96,26 @@ func (mr *MockLessonServiceClientMockRecorder) GetShiftSummary(ctx, in interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShiftSummary", reflect.TypeOf((*MockLessonServiceClient)(nil).GetShiftSummary), varargs...)
 }
 
+// GetTeacherShifts mocks base method.
+func (m *MockLessonServiceClient) GetTeacherShifts(ctx context.Context, in *lesson.GetTeacherShiftsRequest, opts ...grpc.CallOption) (*lesson.GetTeacherShiftsResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetTeacherShifts", varargs...)
+	ret0, _ := ret[0].(*lesson.GetTeacherShiftsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTeacherShifts indicates an expected call of GetTeacherShifts.
+func (mr *MockLessonServiceClientMockRecorder) GetTeacherShifts(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeacherShifts", reflect.TypeOf((*MockLessonServiceClient)(nil).GetTeacherShifts), varargs...)
+}
+
 // ListShiftSummaries mocks base method.
 func (m *MockLessonServiceClient) ListShiftSummaries(ctx context.Context, in *lesson.ListShiftSummariesRequest, opts ...grpc.CallOption) (*lesson.ListShiftSummariesResponse, error) {
 	m.ctrl.T.Helper()
@@ -282,6 +302,21 @@ func (m *MockLessonServiceServer) GetShiftSummary(arg0 context.Context, arg1 *le
 func (mr *MockLessonServiceServerMockRecorder) GetShiftSummary(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShiftSummary", reflect.TypeOf((*MockLessonServiceServer)(nil).GetShiftSummary), arg0, arg1)
+}
+
+// GetTeacherShifts mocks base method.
+func (m *MockLessonServiceServer) GetTeacherShifts(arg0 context.Context, arg1 *lesson.GetTeacherShiftsRequest) (*lesson.GetTeacherShiftsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTeacherShifts", arg0, arg1)
+	ret0, _ := ret[0].(*lesson.GetTeacherShiftsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTeacherShifts indicates an expected call of GetTeacherShifts.
+func (mr *MockLessonServiceServerMockRecorder) GetTeacherShifts(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeacherShifts", reflect.TypeOf((*MockLessonServiceServer)(nil).GetTeacherShifts), arg0, arg1)
 }
 
 // ListShiftSummaries mocks base method.

--- a/api/proto/lesson/service.proto
+++ b/api/proto/lesson/service.proto
@@ -21,6 +21,7 @@ service LessonService {
   rpc CreateShifts(CreateShiftsRequest) returns (CreateShiftsResponse);
   rpc ListTeacherSubmissionsByShiftSummaryIDs(ListTeacherSubmissionsByShiftSummaryIDsRequest) returns (ListTeacherSubmissionsByShiftSummaryIDsResponse);
   rpc ListTeacherShifts(ListTeacherShiftsRequest) returns (ListTeacherShiftsResponse);
+  rpc GetTeacherShifts(GetTeacherShiftsRequest) returns (GetTeacherShiftsResponse);
   rpc UpsertTeacherShifts(UpsertTeacherShiftsRequest) returns (UpsertTeacherShiftsResponse);
 }
 
@@ -93,11 +94,20 @@ message ListTeacherSubmissionsByShiftSummaryIDsResponse {
 }
 
 message ListTeacherShiftsRequest {
+  repeated string teacher_ids      = 1 [(validate.rules).repeated = { unique: true, items: { string: { min_len: 1 }}}];
+  int64           shift_summary_id = 2 [(validate.rules).int64 = { gt: 0 }];
+}
+
+message ListTeacherShiftsResponse {
+  repeated TeacherShift shifts = 1;
+}
+
+message GetTeacherShiftsRequest {
   string teacher_id       = 1 [(validate.rules).string = { min_len: 1 }];
   int64  shift_summary_id = 2 [(validate.rules).int64 = { gt: 0 }];
 }
 
-message ListTeacherShiftsResponse {
+message GetTeacherShiftsResponse {
   TeacherSubmission     submission = 1;
   repeated TeacherShift shifts     = 2;
 }

--- a/docs/swagger/teacher/components/schemas/v1/shifts.response.yaml
+++ b/docs/swagger/teacher/components/schemas/v1/shifts.response.yaml
@@ -118,6 +118,48 @@ shiftsResponse:
                   type: string
                   format: 'HHMM'
                   description: 授業終了時間
+    teachers:
+      type: array
+      description: 講師サマリ一覧
+      items:
+        type: object
+        properties:
+          teacher:
+            type: object
+            description: 講師詳細
+            properties:
+              id:
+                type: string
+                description: 講師ID
+              lastName:
+                type: string
+                description: 姓
+              firstName:
+                type: string
+                description: 名
+              lastNameKana:
+                type: string
+                description: 姓(かな)
+              firstNameKana:
+                type: string
+                description: 名(かな)
+              mail:
+                type: string
+                description: メールアドレス
+              role:
+                type: integer
+                format: int32
+                description: 権限 (0:不明, 1:講師, 2:管理者)
+              createdAt:
+                type: string
+                description: 登録日時
+              updatedAt:
+                type: string
+                description: 更新日時
+          lessonTotal:
+            type: integer
+            format: int64
+            description: 担当授業数
   example:
     summary:
       year: 2022
@@ -149,6 +191,29 @@ shiftsResponse:
       - id: 4
         startTime: '1830'
         endTime: '2000'
+    teachers:
+    - teacher:
+        id: 'kSByoE6FetnPs5Byk3a9Zx'
+        lastName: '中村'
+        firstName: '広大'
+        lastNameKana: 'なかむら'
+        firstNamaKana: 'こうだい'
+        mail: 'teacher-test01@calmato.jp'
+        role: 1
+        createdAt: '2021-12-12T12:12:30.100Z'
+        updatedAt: '2021-12-12T12:12:30.100Z'
+      lessonTotal: 3
+    - teacher:
+        id: 'kSByoE6FetnPs5Byk3a9Zx'
+        lastName: '山田'
+        firstName: 'タダシ'
+        lastNameKana: 'やまだ'
+        firstNamaKana: 'ただし'
+        mail: 'teacher-test02@calmato.jp'
+        role: 2
+        createdAt: '2021-12-12T12:12:30.100Z'
+        updatedAt: '2021-12-12T12:12:30.100Z'
+      lessonTotal: 2
 teacherSubmissionsResponse:
   type: object
   properties:


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
シフト詳細APIのレスポンスへ講師関連情報の追加

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->
* 生徒側の詳細が決まり次第、レスポンスも追加

## 備考

<!-- マージ後に必要な操作などがあればここに -->
