### PR TITLE
fix: 教科変更のイベント検知をchangeメソッドからblurメソッドに変更

### DIFF
--- a/web/teacher/src/components/molecules/TheSubjectSelectFormItem.vue
+++ b/web/teacher/src/components/molecules/TheSubjectSelectFormItem.vue
@@ -17,7 +17,7 @@
       item-text="name"
       item-value="id"
       :items="elementarySchoolSubjects"
-      @change="handleElementarySchoolSubjectsChange"
+      @blur="handleElementarySchoolSubjectsBlur"
     >
       <template #selection="{ item }">
         <v-chip label :color="item.color">{{ item.name }}</v-chip>
@@ -32,7 +32,7 @@
       item-text="name"
       item-value="id"
       :items="juniorHighSchoolSubjects"
-      @change="handleJuniorHighSchoolSubjectsChange"
+      @blur="handleJuniorHighSchoolSubjectsBlur"
     >
       <template #selection="{ item }">
         <v-chip label :color="item.color">{{ item.name }}</v-chip>
@@ -47,7 +47,7 @@
       item-text="name"
       item-value="id"
       :items="highSchoolSubjects"
-      @change="handleHighSchoolSubjectsChange"
+      @blur="handleHighSchoolSubjectsBlur"
     >
       <template #selection="{ item }">
         <v-chip label :color="item.color">{{ item.name }}</v-chip>
@@ -115,25 +115,25 @@ export default defineComponent({
       set: (val: object) => emit('update:highSchoolSubjectsFormValue', val),
     })
 
-    const handleElementarySchoolSubjectsChange = (val: number[]) => {
-      emit('handleElementarySchoolSubjectsChange', val)
+    const handleElementarySchoolSubjectsBlur = () => {
+      emit('handleElementarySchoolSubjectsBlur', props.elementarySchoolSubjectsFormValue)
     }
 
-    const handleJuniorHighSchoolSubjectsChange = (val: number[]) => {
-      emit('handleJuniorHighSchoolSubjectsChange', val)
+    const handleJuniorHighSchoolSubjectsBlur = () => {
+      emit('handleJuniorHighSchoolSubjectsBlur', props.juniorHighSchoolSubjectsFormValue)
     }
 
-    const handleHighSchoolSubjectsChange = (val: number[]) => {
-      emit('handleHighSchoolSubjectsChange', val)
+    const handleHighSchoolSubjectsBlur = () => {
+      emit('handleHighSchoolSubjectsBlur', props.highSchoolSubjectsFormValue)
     }
 
     return {
       elementarySchoolSubjectsFormData,
       juniorHighSchoolSubjectsFormData,
       highSchoolSubjectsFormData,
-      handleElementarySchoolSubjectsChange,
-      handleJuniorHighSchoolSubjectsChange,
-      handleHighSchoolSubjectsChange,
+      handleElementarySchoolSubjectsBlur,
+      handleJuniorHighSchoolSubjectsBlur,
+      handleHighSchoolSubjectsBlur,
     }
   },
 })

--- a/web/teacher/src/components/templates/TheSettingTop.vue
+++ b/web/teacher/src/components/templates/TheSettingTop.vue
@@ -12,9 +12,9 @@
       :elementary-school-subjects="elementarySchoolSubjects"
       :junior-high-school-subjects="juniorHighSchoolSubjects"
       :high-school-subjects="highSchoolSubjects"
-      @handleElementarySchoolSubjectsChange="handleElementarySchoolSubjectsChange"
-      @handleJuniorHighSchoolSubjectsChange="handleJuniorHighSchoolSubjectsChange"
-      @handleHighSchoolSubjectsChange="handleHighSchoolSubjectsChange"
+      @handleElementarySchoolSubjectsBlur="handleElementarySchoolSubjectsBlur"
+      @handleJuniorHighSchoolSubjectsBlur="handleJuniorHighSchoolSubjectsBlur"
+      @handleHighSchoolSubjectsBlur="handleHighSchoolSubjectsBlur"
     />
     <v-row class="py-4">
       <v-col cols="12">
@@ -133,16 +133,16 @@ export default defineComponent({
       set: (val: object) => emit('update:highSchoolSubjectsFormValue', val),
     })
 
-    const handleElementarySchoolSubjectsChange = (val: number[]) => {
-      emit('handleElementarySchoolSubjectsChange', val)
+    const handleElementarySchoolSubjectsBlur = (val: number[]) => {
+      emit('handleElementarySchoolSubjectsBlur', val)
     }
 
-    const handleJuniorHighSchoolSubjectsChange = (val: number[]) => {
-      emit('handleJuniorHighSchoolSubjectsChange', val)
+    const handleJuniorHighSchoolSubjectsBlur = (val: number[]) => {
+      emit('handleJuniorHighSchoolSubjectsBlur', val)
     }
 
-    const handleHighSchoolSubjectsChange = (val: number[]) => {
-      emit('handleHighSchoolSubjectsChange', val)
+    const handleHighSchoolSubjectsBlur = (val: number[]) => {
+      emit('handleHighSchoolSubjectsBlur', val)
     }
 
     return {
@@ -151,9 +151,9 @@ export default defineComponent({
       elementarySchoolSubjectsFormData,
       juniorHighSchoolSubjectsFormData,
       highSchoolSubjectsFormData,
-      handleElementarySchoolSubjectsChange,
-      handleJuniorHighSchoolSubjectsChange,
-      handleHighSchoolSubjectsChange,
+      handleElementarySchoolSubjectsBlur,
+      handleJuniorHighSchoolSubjectsBlur,
+      handleHighSchoolSubjectsBlur,
     }
   },
 })

--- a/web/teacher/src/pages/settings/index.vue
+++ b/web/teacher/src/pages/settings/index.vue
@@ -10,9 +10,9 @@
     :elementary-school-subjects-form-value.sync="elementarySchoolSubjectForm.subjectIDs"
     :junior-high-school-subjects-form-value.sync="juniorHighSchoolSubjectForm.subjectIDs"
     :high-school-subjects-form-value.sync="highSchoolSubjectForm.subjectIDs"
-    @handleElementarySchoolSubjectsChange="handleElementarySchoolSubjectsChange"
-    @handleJuniorHighSchoolSubjectsChange="handleJuniorHighSchoolSubjectsChange"
-    @handleHighSchoolSubjectsChange="handleHighSchoolSubjectsChange"
+    @handleElementarySchoolSubjectsBlur="handleElementarySchoolSubjectsBlur"
+    @handleJuniorHighSchoolSubjectsBlur="handleJuniorHighSchoolSubjectsBlur"
+    @handleHighSchoolSubjectsBlur="handleHighSchoolSubjectsBlur"
     @click="handleClick"
     @onClickBackButton="handleBackButton"
   />
@@ -95,15 +95,15 @@ export default defineComponent({
       router.back()
     }
 
-    const handleElementarySchoolSubjectsChange = (_val: number[]) => {
+    const handleElementarySchoolSubjectsBlur = (_val: number[]) => {
       AuthStore.updateOwnSubjects(elementarySchoolSubjectForm)
     }
 
-    const handleJuniorHighSchoolSubjectsChange = (_val: number[]) => {
+    const handleJuniorHighSchoolSubjectsBlur = (_val: number[]) => {
       AuthStore.updateOwnSubjects(juniorHighSchoolSubjectForm)
     }
 
-    const handleHighSchoolSubjectsChange = (_val: number[]) => {
+    const handleHighSchoolSubjectsBlur = (_val: number[]) => {
       AuthStore.updateOwnSubjects(highSchoolSubjectForm)
     }
 
@@ -140,9 +140,9 @@ export default defineComponent({
       elementarySchoolSubjectForm,
       juniorHighSchoolSubjectForm,
       highSchoolSubjectForm,
-      handleElementarySchoolSubjectsChange,
-      handleJuniorHighSchoolSubjectsChange,
-      handleHighSchoolSubjectsChange,
+      handleElementarySchoolSubjectsBlur,
+      handleJuniorHighSchoolSubjectsBlur,
+      handleHighSchoolSubjectsBlur,
     }
   },
 })


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
- APIリクエストの数を減らすためににも教科を変更するイベント検知を`change`から`blur`に変更

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

特になし。
<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

特になし。
<!-- マージ後に必要な操作などがあればここに -->
