### PR TITLE
feat(web/teacher): コマ/ブース設定画面のUIだけ作成

### DIFF
--- a/web/teacher/src/pages/settings/classroom.vue
+++ b/web/teacher/src/pages/settings/classroom.vue
@@ -13,7 +13,7 @@
     </div>
     <div>
       <p class="text-h5 mb-2">ブース数の設定</p>
-      <p class="text-body-2">使用するブース数を入力したください。</p>
+      <p class="text-body-2">使用するブース数を選択してください。</p>
       <v-select v-model="boothRef" type="number" :items="boothList" />
     </div>
     <div>

--- a/web/teacher/src/pages/settings/classroom.vue
+++ b/web/teacher/src/pages/settings/classroom.vue
@@ -1,0 +1,79 @@
+<template>
+  <v-container>
+    <div class="mb-2">
+      <p class="text-h5 mb-2">定休日の設定</p>
+      <p class="text-body-2">定休日とする曜日にチェックをつけてください。</p>
+      <v-checkbox
+        v-for="(dateString, i) in dateList"
+        :key="i"
+        class="ma-0 pt-0"
+        :label="dateString"
+        :value="dateString"
+      />
+    </div>
+    <div>
+      <p class="text-h5 mb-2">ブース数の設定</p>
+      <p class="text-body-2">使用するブース数を入力したください。</p>
+      <v-select v-model="boothRef" type="number" :items="boothList" />
+    </div>
+    <div>
+      <p class="text-h5 mb-2">コマ設定</p>
+      <div class="d-flex align-center my-2">
+        <p class="text-subtitle-1 mr-4 mb-0">平日</p>
+        <v-btn class="suffix-btn" color="primary" fab elevation="0"><v-icon>mdi-plus</v-icon></v-btn>
+      </div>
+      <div>
+        <div class="stack d-flex align-center">
+          <p>1.</p>
+          <v-text-field type="time" label="開始時刻" step="300" min="17:00" max="21:30" />
+          <span>~</span>
+          <v-text-field type="time" label="終了時刻" step="300" min="17:00" max="21:30" />
+          <v-btn class="suffix-btn" color="error" fab elevation="0"><v-icon>mdi-minus</v-icon></v-btn>
+        </div>
+      </div>
+      <div class="d-flex align-center my-2">
+        <p class="text-subtitle-1 mr-4 mb-0">休日</p>
+        <v-btn class="suffix-btn" color="primary" fab elevation="0"><v-icon>mdi-plus</v-icon></v-btn>
+      </div>
+      <div>
+        <div class="stack d-flex align-center">
+          <p>1.</p>
+          <v-text-field type="time" label="開始時刻" step="300" min="17:00" max="21:30" />
+          <span>~</span>
+          <v-text-field type="time" label="終了時刻" step="300" min="17:00" max="21:30" />
+          <v-btn class="suffix-btn" color="error" fab elevation="0"><v-icon>mdi-minus</v-icon></v-btn>
+        </div>
+      </div>
+    </div>
+  </v-container>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, Ref } from '@nuxtjs/composition-api'
+
+export default defineComponent({
+  setup() {
+    const boothRef: Ref<number> = ref<number>(1)
+
+    const dateList: string[] = ['月曜日', '火曜日', '水曜日', '木曜日', '金曜日', '土曜日', '日曜日']
+    const boothList: number[] = [1, 2, 3, 4, 5]
+
+    return {
+      boothRef,
+      dateList,
+      boothList,
+    }
+  },
+})
+</script>
+
+<style lang="scss" scoped>
+.stack {
+  gap: var(--space, 1rem);
+}
+
+.suffix-btn {
+  height: 24px;
+  width: 24px;
+}
+</style>

--- a/web/teacher/src/pages/settings/index.vue
+++ b/web/teacher/src/pages/settings/index.vue
@@ -51,8 +51,8 @@ export default defineComponent({
         path: '#教室・科目設定',
       },
       {
-        title: 'コマ設定',
-        path: '#コマ設定',
+        title: '定休日/コマ/ブース 設定',
+        path: '/settings/classroom',
       },
     ]
 


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
- コマ/ブース設定画面のUIだけ作成

<img alt="localhost_3000_settings_classroom" src="https://user-images.githubusercontent.com/27722351/149156294-063d384e-c59d-4405-8e60-0b5e5aba9c37.png" width="500px" />

### レビュー時のポイント

- パスの設定がわからなかったので`settings/classroom`にした。

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

- コンポーネント化
- ロジックなど
- APIとの接続
<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
