### PR TITLE
feat(lesson-api): define student submissions entity

### DIFF
--- a/api/internal/lesson/entity/student_shift.go
+++ b/api/internal/lesson/entity/student_shift.go
@@ -1,0 +1,51 @@
+package entity
+
+import (
+	"time"
+
+	"github.com/calmato/shs-web/api/proto/lesson"
+)
+
+type StudentShift struct {
+	StudentID      string    `gorm:"primaryKey;<-:create"`
+	ShiftID        int64     `gorm:"primaryKey;<-:create"`
+	ShiftSummaryID int64     `gorm:""`
+	CreatedAt      time.Time `gorm:"<-:create"`
+	UpdatedAt      time.Time `gorm:""`
+}
+
+type StudentShifts []*StudentShift
+
+func NewStudentShift(studentID string, summaryID int64, shiftID int64) *StudentShift {
+	return &StudentShift{
+		StudentID:      studentID,
+		ShiftID:        shiftID,
+		ShiftSummaryID: summaryID,
+	}
+}
+
+func NewStudentShifts(studentID string, summaryID int64, shiftIDs []int64) StudentShifts {
+	ss := make(StudentShifts, len(shiftIDs))
+	for i := range shiftIDs {
+		ss[i] = NewStudentShift(studentID, summaryID, shiftIDs[i])
+	}
+	return ss
+}
+
+func (s *StudentShift) Proto() *lesson.StudentShift {
+	return &lesson.StudentShift{
+		StudentId:      s.StudentID,
+		ShiftId:        s.ShiftID,
+		ShiftSummaryId: s.ShiftSummaryID,
+		CreatedAt:      s.CreatedAt.Unix(),
+		UpdatedAt:      s.CreatedAt.Unix(),
+	}
+}
+
+func (ss StudentShifts) Proto() []*lesson.StudentShift {
+	shifts := make([]*lesson.StudentShift, len(ss))
+	for i := range ss {
+		shifts[i] = ss[i].Proto()
+	}
+	return shifts
+}

--- a/api/internal/lesson/entity/student_shift_test.go
+++ b/api/internal/lesson/entity/student_shift_test.go
@@ -1,0 +1,156 @@
+package entity
+
+import (
+	"testing"
+
+	"github.com/calmato/shs-web/api/pkg/jst"
+	"github.com/calmato/shs-web/api/proto/lesson"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStudentShift(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		studentID string
+		summaryID int64
+		shiftID   int64
+		expect    *StudentShift
+	}{
+		{
+			name:      "success",
+			studentID: "studentid",
+			summaryID: 1,
+			shiftID:   1,
+			expect: &StudentShift{
+				StudentID:      "studentid",
+				ShiftID:        1,
+				ShiftSummaryID: 1,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := NewStudentShift(tt.studentID, tt.summaryID, tt.shiftID)
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}
+
+func TestStudentShifts(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		studentID string
+		summaryID int64
+		shiftIDs  []int64
+		expect    StudentShifts
+	}{
+		{
+			name:      "success",
+			studentID: "studentid",
+			summaryID: 1,
+			shiftIDs:  []int64{1, 2},
+			expect: StudentShifts{
+				{
+					StudentID:      "studentid",
+					ShiftID:        1,
+					ShiftSummaryID: 1,
+				},
+				{
+					StudentID:      "studentid",
+					ShiftID:        2,
+					ShiftSummaryID: 1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := NewStudentShifts(tt.studentID, tt.summaryID, tt.shiftIDs)
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}
+
+func TestStudentShift_Proto(t *testing.T) {
+	t.Parallel()
+	now := jst.Now()
+	tests := []struct {
+		name   string
+		shift  *StudentShift
+		expect *lesson.StudentShift
+	}{
+		{
+			name: "success",
+			shift: &StudentShift{
+				StudentID:      "studentid",
+				ShiftID:        1,
+				ShiftSummaryID: 1,
+				CreatedAt:      now,
+				UpdatedAt:      now,
+			},
+			expect: &lesson.StudentShift{
+				StudentId:      "studentid",
+				ShiftId:        1,
+				ShiftSummaryId: 1,
+				CreatedAt:      now.Unix(),
+				UpdatedAt:      now.Unix(),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.shift.Proto())
+		})
+	}
+}
+
+func TestStudentShifts_Proto(t *testing.T) {
+	t.Parallel()
+	now := jst.Now()
+	tests := []struct {
+		name   string
+		shifts StudentShifts
+		expect []*lesson.StudentShift
+	}{
+		{
+			name: "success",
+			shifts: StudentShifts{
+				{
+					StudentID:      "studentid",
+					ShiftID:        1,
+					ShiftSummaryID: 1,
+					CreatedAt:      now,
+					UpdatedAt:      now,
+				},
+			},
+			expect: []*lesson.StudentShift{
+				{
+					StudentId:      "studentid",
+					ShiftId:        1,
+					ShiftSummaryId: 1,
+					CreatedAt:      now.Unix(),
+					UpdatedAt:      now.Unix(),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.shifts.Proto())
+		})
+	}
+}

--- a/api/internal/lesson/entity/student_submission.go
+++ b/api/internal/lesson/entity/student_submission.go
@@ -1,0 +1,43 @@
+package entity
+
+import (
+	"time"
+
+	"github.com/calmato/shs-web/api/proto/lesson"
+)
+
+type StudentSubmission struct {
+	StudentID      string    `gorm:"primaryKey;<-:create"`
+	ShiftSummaryID int64     `gorm:"primaryKey;<-:create"`
+	Decided        bool      `gorm:""`
+	CreatedAt      time.Time `gorm:"<-:create"`
+	UpdatedAt      time.Time `gorm:""`
+}
+
+type StudentSubmissions []*StudentSubmission
+
+func NewStudentSubmission(studentID string, summaryID int64, decided bool) *StudentSubmission {
+	return &StudentSubmission{
+		StudentID:      studentID,
+		ShiftSummaryID: summaryID,
+		Decided:        decided,
+	}
+}
+
+func (s *StudentSubmission) Proto() *lesson.StudentSubmission {
+	return &lesson.StudentSubmission{
+		StudentId:      s.StudentID,
+		ShiftSummaryId: s.ShiftSummaryID,
+		Decided:        s.Decided,
+		CreatedAt:      s.CreatedAt.Unix(),
+		UpdatedAt:      s.UpdatedAt.Unix(),
+	}
+}
+
+func (ss StudentSubmissions) Proto() []*lesson.StudentSubmission {
+	submissions := make([]*lesson.StudentSubmission, len(ss))
+	for i := range ss {
+		submissions[i] = ss[i].Proto()
+	}
+	return submissions
+}

--- a/api/internal/lesson/entity/student_submission_test.go
+++ b/api/internal/lesson/entity/student_submission_test.go
@@ -1,0 +1,117 @@
+package entity
+
+import (
+	"testing"
+
+	"github.com/calmato/shs-web/api/pkg/jst"
+	"github.com/calmato/shs-web/api/proto/lesson"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStudentSubmission(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		studentiD string
+		summaryID int64
+		decided   bool
+		expect    *StudentSubmission
+	}{
+		{
+			name:      "success",
+			studentiD: "studentid",
+			summaryID: 1,
+			decided:   true,
+			expect: &StudentSubmission{
+				StudentID:      "studentid",
+				ShiftSummaryID: 1,
+				Decided:        true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual := NewStudentSubmission(tt.studentiD, tt.summaryID, tt.decided)
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}
+
+func TestStudentSubmission_Proto(t *testing.T) {
+	t.Parallel()
+	now := jst.Now()
+	tests := []struct {
+		name       string
+		submission *StudentSubmission
+		expect     *lesson.StudentSubmission
+	}{
+		{
+			name: "success",
+			submission: &StudentSubmission{
+				StudentID:      "studentid",
+				ShiftSummaryID: 1,
+				Decided:        true,
+				CreatedAt:      now,
+				UpdatedAt:      now,
+			},
+			expect: &lesson.StudentSubmission{
+				StudentId:      "studentid",
+				ShiftSummaryId: 1,
+				Decided:        true,
+				CreatedAt:      now.Unix(),
+				UpdatedAt:      now.Unix(),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.submission.Proto())
+		})
+	}
+}
+
+func TestStudentSubmissions_Proto(t *testing.T) {
+	t.Parallel()
+	now := jst.Now()
+	tests := []struct {
+		name        string
+		submissions StudentSubmissions
+		expect      []*lesson.StudentSubmission
+	}{
+		{
+			name: "success",
+			submissions: StudentSubmissions{
+				{
+					StudentID:      "studentid",
+					ShiftSummaryID: 1,
+					Decided:        true,
+					CreatedAt:      now,
+					UpdatedAt:      now,
+				},
+			},
+			expect: []*lesson.StudentSubmission{
+				{
+					StudentId:      "studentid",
+					ShiftSummaryId: 1,
+					Decided:        true,
+					CreatedAt:      now.Unix(),
+					UpdatedAt:      now.Unix(),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.submissions.Proto())
+		})
+	}
+}

--- a/api/proto/lesson/student_shift.proto
+++ b/api/proto/lesson/student_shift.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package lesson;
+
+option go_package = "github.com/calmato/shs-web/api/proto/lesson";
+
+message StudentShift {
+  string student_id       = 1;
+  int64  shift_id         = 2;
+  int64  shift_summary_id = 3;
+  int64  created_at       = 4;
+  int64  updated_at       = 5;
+}

--- a/api/proto/lesson/student_submission.proto
+++ b/api/proto/lesson/student_submission.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package lesson;
+
+option go_package = "github.com/calmato/shs-web/api/proto/lesson";
+
+message StudentSubmission {
+  string student_id       = 1;
+  int64  shift_summary_id = 2;
+  bool   decided          = 3;
+  int64  created_at       = 4;
+  int64  updated_at       = 5;
+}

--- a/infra/mysql/schema/2022011401-lessons-create-table-student-shifts.sql
+++ b/infra/mysql/schema/2022011401-lessons-create-table-student-shifts.sql
@@ -1,0 +1,31 @@
+CREATE TABLE `lessons`.`student_submissions` (
+  `student_id`       VARCHAR(22) NOT NULL, -- 生徒ID
+  `shift_summary_id` BIGINT      NOT NULL, -- 授業スケジュールサマリID
+  `decided`          TINYINT     NOT NULL, -- 確定フラグ
+  `created_at`       DATETIME    NOT NULL, -- 登録日時
+  `updated_at`       DATETIME    NOT NULL, -- 更新日時
+  PRIMARY KEY(`student_id`, `shift_summary_id` DESC),
+  CONSTRAINT `fk_student_submissions_shift_summaries_id`
+    FOREIGN KEY (`shift_summary_id`) REFERENCES `lessons`.`shift_summaries` (`id`)
+    ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE = InnoDB;
+
+CREATE TABLE `lessons`.`student_shifts` (
+  `student_id`       VARCHAR(22) NOT NULL, -- 生徒ID
+  `shift_summary_id` BIGINT      NOT NULL, -- 授業スケジュールサマリID
+  `shift_id`         BIGINT      NOT NULL, -- 授業スケジュールID
+  `created_at`       DATETIME    NOT NULL, -- 登録日時
+  `updated_at`       DATETIME    NOT NULL, -- 更新日時
+  PRIMARY KEY(`student_id`, `shift_id` DESC),
+  CONSTRAINT `fk_student_shifts_shift_summaries_id`
+    FOREIGN KEY (`shift_summary_id`) REFERENCES `lessons`.`shift_summaries` (`id`)
+    ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `fk_student_shifts_shifts_id`
+    FOREIGN KEY (`shift_id`) REFERENCES `lessons`.`shifts` (`id`)
+    ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE = InnoDB;
+
+CREATE INDEX `idex_student_shifts_shift_summary_id_student_id`
+  ON `lessons`.`student_shifts` (`shift_summary_id` DESC, `student_id` ASC) VISIBLE;
+CREATE INDEX `idex_student_shifts_shift_id_student_id`
+  ON `lessons`.`student_shifts` (`shift_id` DESC, `student_id` ASC) VISIBLE;


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
生徒の授業希望を管理するためのDDLを作成しました。
授業希望なので `student_lessons` とかの命名のほうが適切かと考えたのですが、先につくっている講師のシフト希望 `teacher_shifts` と併せたほうがわかりやすいので、テーブル名は `student_shifts` にしてます。

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
