### PR TITLE
feat(lesson-api): add field to student submission entity

### DIFF
--- a/api/internal/lesson/api/student_shift.go
+++ b/api/internal/lesson/api/student_shift.go
@@ -115,7 +115,7 @@ func (s *lessonService) UpsertStudentShifts(
 		return nil, status.Error(codes.FailedPrecondition, "api: outside of shift submission")
 	}
 
-	submission := entity.NewStudentSubmission(req.StudentId, req.ShiftSummaryId, req.Decided)
+	submission := entity.NewStudentSubmission(req.StudentId, req.ShiftSummaryId, req.Decided, req.SuggestedClasses)
 	shifts := entity.NewStudentShifts(req.StudentId, req.ShiftSummaryId, req.ShiftIds)
 	err := s.db.StudentShift.Replace(ctx, submission, shifts)
 	if err != nil {

--- a/api/internal/lesson/api/student_shift_test.go
+++ b/api/internal/lesson/api/student_shift_test.go
@@ -24,18 +24,20 @@ func TestListStudentSubmissionsByShiftSummaryID(t *testing.T) {
 	}
 	submissions := entity.StudentSubmissions{
 		{
-			StudentID:      "studentid",
-			ShiftSummaryID: 1,
-			Decided:        true,
-			CreatedAt:      now,
-			UpdatedAt:      now,
+			StudentID:        "studentid",
+			ShiftSummaryID:   1,
+			Decided:          true,
+			SuggestedClasses: 8,
+			CreatedAt:        now,
+			UpdatedAt:        now,
 		},
 		{
-			StudentID:      "studentid",
-			ShiftSummaryID: 2,
-			Decided:        false,
-			CreatedAt:      now,
-			UpdatedAt:      now,
+			StudentID:        "studentid",
+			ShiftSummaryID:   2,
+			Decided:          false,
+			SuggestedClasses: 8,
+			CreatedAt:        now,
+			UpdatedAt:        now,
 		},
 	}
 
@@ -57,18 +59,20 @@ func TestListStudentSubmissionsByShiftSummaryID(t *testing.T) {
 				body: &lesson.ListStudentSubmissionsByShiftSummaryIDsResponse{
 					Submissions: []*lesson.StudentSubmission{
 						{
-							StudentId:      "studentid",
-							ShiftSummaryId: 1,
-							Decided:        true,
-							CreatedAt:      now.Unix(),
-							UpdatedAt:      now.Unix(),
+							StudentId:        "studentid",
+							ShiftSummaryId:   1,
+							Decided:          true,
+							SuggestedClasses: 8,
+							CreatedAt:        now.Unix(),
+							UpdatedAt:        now.Unix(),
 						},
 						{
-							StudentId:      "studentid",
-							ShiftSummaryId: 2,
-							Decided:        false,
-							CreatedAt:      now.Unix(),
-							UpdatedAt:      now.Unix(),
+							StudentId:        "studentid",
+							ShiftSummaryId:   2,
+							Decided:          false,
+							SuggestedClasses: 8,
+							CreatedAt:        now.Unix(),
+							UpdatedAt:        now.Unix(),
 						},
 					},
 				},
@@ -198,9 +202,10 @@ func TestGetStudentShifts(t *testing.T) {
 		ShiftSummaryId: 1,
 	}
 	submission := &entity.StudentSubmission{
-		StudentID:      "studentid",
-		ShiftSummaryID: 1,
-		Decided:        true,
+		StudentID:        "studentid",
+		ShiftSummaryID:   1,
+		Decided:          true,
+		SuggestedClasses: 8,
 	}
 	shifts := entity.StudentShifts{
 		{
@@ -233,11 +238,12 @@ func TestGetStudentShifts(t *testing.T) {
 				code: codes.OK,
 				body: &lesson.GetStudentShiftsResponse{
 					Submission: &lesson.StudentSubmission{
-						StudentId:      "studentid",
-						ShiftSummaryId: 1,
-						Decided:        true,
-						CreatedAt:      time.Time{}.Unix(),
-						UpdatedAt:      time.Time{}.Unix(),
+						StudentId:        "studentid",
+						ShiftSummaryId:   1,
+						Decided:          true,
+						SuggestedClasses: 8,
+						CreatedAt:        time.Time{}.Unix(),
+						UpdatedAt:        time.Time{}.Unix(),
 					},
 					Shifts: []*lesson.StudentShift{
 						{
@@ -306,10 +312,11 @@ func TestGetStudentShifts(t *testing.T) {
 func TestUpsertStudentShifts(t *testing.T) {
 	t.Parallel()
 	req := &lesson.UpsertStudentShiftsRequest{
-		StudentId:      "studentid",
-		ShiftSummaryId: 1,
-		ShiftIds:       []int64{1, 2},
-		Decided:        true,
+		StudentId:        "studentid",
+		ShiftSummaryId:   1,
+		ShiftIds:         []int64{1, 2},
+		Decided:          true,
+		SuggestedClasses: 8,
 	}
 	student := &user.Student{Id: "studentid"}
 	summary := &entity.ShiftSummary{
@@ -321,9 +328,10 @@ func TestUpsertStudentShifts(t *testing.T) {
 		{ID: 2, ShiftSummaryID: 1},
 	}
 	studentSubmission := &entity.StudentSubmission{
-		StudentID:      "studentid",
-		ShiftSummaryID: 1,
-		Decided:        true,
+		StudentID:        "studentid",
+		ShiftSummaryID:   1,
+		Decided:          true,
+		SuggestedClasses: 8,
 	}
 	studentShifts := entity.StudentShifts{
 		{
@@ -360,11 +368,12 @@ func TestUpsertStudentShifts(t *testing.T) {
 				code: codes.OK,
 				body: &lesson.UpsertStudentShiftsResponse{
 					Submission: &lesson.StudentSubmission{
-						StudentId:      "studentid",
-						ShiftSummaryId: 1,
-						Decided:        true,
-						CreatedAt:      time.Time{}.Unix(),
-						UpdatedAt:      time.Time{}.Unix(),
+						StudentId:        "studentid",
+						ShiftSummaryId:   1,
+						Decided:          true,
+						SuggestedClasses: 8,
+						CreatedAt:        time.Time{}.Unix(),
+						UpdatedAt:        time.Time{}.Unix(),
 					},
 					Shifts: []*lesson.StudentShift{
 						{

--- a/api/internal/lesson/database/student_submission.go
+++ b/api/internal/lesson/database/student_submission.go
@@ -12,7 +12,8 @@ import (
 const studentSubmissionTable = "student_submissions"
 
 var studentSubmissionFields = []string{
-	"student_id", "shift_summary_id", "decided", "created_at", "updated_at",
+	"student_id", "shift_summary_id", "decided",
+	"suggested_classes", "created_at", "updated_at",
 }
 
 type studentSubmission struct {

--- a/api/internal/lesson/database/student_submission_test.go
+++ b/api/internal/lesson/database/student_submission_test.go
@@ -182,10 +182,11 @@ func TestStudentSubmission_Get(t *testing.T) {
 
 func testStudentSubmission(studentID string, summaryID int64, decided bool, now time.Time) *entity.StudentSubmission {
 	return &entity.StudentSubmission{
-		StudentID:      studentID,
-		ShiftSummaryID: summaryID,
-		Decided:        decided,
-		CreatedAt:      now,
-		UpdatedAt:      now,
+		StudentID:        studentID,
+		ShiftSummaryID:   summaryID,
+		Decided:          decided,
+		SuggestedClasses: 8,
+		CreatedAt:        now,
+		UpdatedAt:        now,
 	}
 }

--- a/api/internal/lesson/entity/student_submission.go
+++ b/api/internal/lesson/entity/student_submission.go
@@ -7,30 +7,35 @@ import (
 )
 
 type StudentSubmission struct {
-	StudentID      string    `gorm:"primaryKey;<-:create"`
-	ShiftSummaryID int64     `gorm:"primaryKey;<-:create"`
-	Decided        bool      `gorm:""`
-	CreatedAt      time.Time `gorm:"<-:create"`
-	UpdatedAt      time.Time `gorm:""`
+	StudentID        string    `gorm:"primaryKey;<-:create"`
+	ShiftSummaryID   int64     `gorm:"primaryKey;<-:create"`
+	Decided          bool      `gorm:""`
+	SuggestedClasses int64     `gorm:""`
+	CreatedAt        time.Time `gorm:"<-:create"`
+	UpdatedAt        time.Time `gorm:""`
 }
 
 type StudentSubmissions []*StudentSubmission
 
-func NewStudentSubmission(studentID string, summaryID int64, decided bool) *StudentSubmission {
+func NewStudentSubmission(
+	studentID string, summaryID int64, decided bool, suggestedClasses int64,
+) *StudentSubmission {
 	return &StudentSubmission{
-		StudentID:      studentID,
-		ShiftSummaryID: summaryID,
-		Decided:        decided,
+		StudentID:        studentID,
+		ShiftSummaryID:   summaryID,
+		Decided:          decided,
+		SuggestedClasses: suggestedClasses,
 	}
 }
 
 func (s *StudentSubmission) Proto() *lesson.StudentSubmission {
 	return &lesson.StudentSubmission{
-		StudentId:      s.StudentID,
-		ShiftSummaryId: s.ShiftSummaryID,
-		Decided:        s.Decided,
-		CreatedAt:      s.CreatedAt.Unix(),
-		UpdatedAt:      s.UpdatedAt.Unix(),
+		StudentId:        s.StudentID,
+		ShiftSummaryId:   s.ShiftSummaryID,
+		Decided:          s.Decided,
+		SuggestedClasses: s.SuggestedClasses,
+		CreatedAt:        s.CreatedAt.Unix(),
+		UpdatedAt:        s.UpdatedAt.Unix(),
 	}
 }
 

--- a/api/internal/lesson/entity/student_submission_test.go
+++ b/api/internal/lesson/entity/student_submission_test.go
@@ -11,21 +11,24 @@ import (
 func TestStudentSubmission(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name      string
-		studentiD string
-		summaryID int64
-		decided   bool
-		expect    *StudentSubmission
+		name             string
+		studentiD        string
+		summaryID        int64
+		decided          bool
+		suggestedClasses int64
+		expect           *StudentSubmission
 	}{
 		{
-			name:      "success",
-			studentiD: "studentid",
-			summaryID: 1,
-			decided:   true,
+			name:             "success",
+			studentiD:        "studentid",
+			summaryID:        1,
+			decided:          true,
+			suggestedClasses: 8,
 			expect: &StudentSubmission{
-				StudentID:      "studentid",
-				ShiftSummaryID: 1,
-				Decided:        true,
+				StudentID:        "studentid",
+				ShiftSummaryID:   1,
+				Decided:          true,
+				SuggestedClasses: 8,
 			},
 		},
 	}
@@ -34,7 +37,7 @@ func TestStudentSubmission(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			actual := NewStudentSubmission(tt.studentiD, tt.summaryID, tt.decided)
+			actual := NewStudentSubmission(tt.studentiD, tt.summaryID, tt.decided, tt.suggestedClasses)
 			assert.Equal(t, tt.expect, actual)
 		})
 	}
@@ -51,18 +54,20 @@ func TestStudentSubmission_Proto(t *testing.T) {
 		{
 			name: "success",
 			submission: &StudentSubmission{
-				StudentID:      "studentid",
-				ShiftSummaryID: 1,
-				Decided:        true,
-				CreatedAt:      now,
-				UpdatedAt:      now,
+				StudentID:        "studentid",
+				ShiftSummaryID:   1,
+				Decided:          true,
+				SuggestedClasses: 8,
+				CreatedAt:        now,
+				UpdatedAt:        now,
 			},
 			expect: &lesson.StudentSubmission{
-				StudentId:      "studentid",
-				ShiftSummaryId: 1,
-				Decided:        true,
-				CreatedAt:      now.Unix(),
-				UpdatedAt:      now.Unix(),
+				StudentId:        "studentid",
+				ShiftSummaryId:   1,
+				Decided:          true,
+				SuggestedClasses: 8,
+				CreatedAt:        now.Unix(),
+				UpdatedAt:        now.Unix(),
 			},
 		},
 	}
@@ -88,20 +93,22 @@ func TestStudentSubmissions_Proto(t *testing.T) {
 			name: "success",
 			submissions: StudentSubmissions{
 				{
-					StudentID:      "studentid",
-					ShiftSummaryID: 1,
-					Decided:        true,
-					CreatedAt:      now,
-					UpdatedAt:      now,
+					StudentID:        "studentid",
+					ShiftSummaryID:   1,
+					Decided:          true,
+					SuggestedClasses: 8,
+					CreatedAt:        now,
+					UpdatedAt:        now,
 				},
 			},
 			expect: []*lesson.StudentSubmission{
 				{
-					StudentId:      "studentid",
-					ShiftSummaryId: 1,
-					Decided:        true,
-					CreatedAt:      now.Unix(),
-					UpdatedAt:      now.Unix(),
+					StudentId:        "studentid",
+					ShiftSummaryId:   1,
+					Decided:          true,
+					SuggestedClasses: 8,
+					CreatedAt:        now.Unix(),
+					UpdatedAt:        now.Unix(),
 				},
 			},
 		},

--- a/api/proto/lesson/service.proto
+++ b/api/proto/lesson/service.proto
@@ -159,10 +159,11 @@ message GetStudentShiftsResponse {
 }
 
 message UpsertStudentShiftsRequest {
-  string         student_id       = 1 [(validate.rules).string = { min_len: 1 }];
-  int64          shift_summary_id = 2 [(validate.rules).int64 = { gt: 0 }];
-  repeated int64 shift_ids        = 3 [(validate.rules).repeated = { unique: true, items: { int64: { gt: 0 }}}];
-  bool           decided          = 4;
+  string         student_id        = 1 [(validate.rules).string = { min_len: 1 }];
+  int64          shift_summary_id  = 2 [(validate.rules).int64 = { gt: 0 }];
+  repeated int64 shift_ids         = 3 [(validate.rules).repeated = { unique: true, items: { int64: { gt: 0 }}}];
+  bool           decided           = 4;
+  int64          suggested_classes = 5 [(validate.rules).int64 = { gte: 0 }];
 }
 
 message UpsertStudentShiftsResponse {

--- a/api/proto/lesson/student_submission.proto
+++ b/api/proto/lesson/student_submission.proto
@@ -5,9 +5,10 @@ package lesson;
 option go_package = "github.com/calmato/shs-web/api/proto/lesson";
 
 message StudentSubmission {
-  string student_id       = 1;
-  int64  shift_summary_id = 2;
-  bool   decided          = 3;
-  int64  created_at       = 4;
-  int64  updated_at       = 5;
+  string student_id        = 1;
+  int64  shift_summary_id  = 2;
+  bool   decided           = 3;
+  int64  suggested_classes = 4;
+  int64  created_at        = 5;
+  int64  updated_at        = 6;
 }

--- a/infra/mysql/schema/2022011501-lessons-add-column-to-student-submissions.sql
+++ b/infra/mysql/schema/2022011501-lessons-add-column-to-student-submissions.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `lessons`.`student_submissions` ADD COLUMN `suggested_classes` INT NOT NULL AFTER `decided`;


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
生徒の授業希望管理テーブルへ希望授業回数を管理するためのカラムを追加しました

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
