### PR TITLE
feat(user-api): add DeleteStudent database layer

### DIFF
--- a/api/internal/user/database/database.go
+++ b/api/internal/user/database/database.go
@@ -48,6 +48,7 @@ type Student interface {
 	List(ctx context.Context, p *ListStudentsParams, fields ...string) (entity.Students, error)
 	Get(ctx context.Context, id string, fields ...string) (*entity.Student, error)
 	Create(ctx context.Context, s *entity.Student) error
+	Delete(ctx context.Context, studentID string) error
 	Count(ctx context.Context) (int64, error)
 }
 

--- a/api/internal/user/database/student.go
+++ b/api/internal/user/database/student.go
@@ -116,7 +116,6 @@ func (s *student) Delete(ctx context.Context, studentID string) error {
 		return dbError(err)
 	}
 	return dbError(tx.Commit().Error)
-
 }
 
 func (s *student) Count(ctx context.Context) (int64, error) {

--- a/api/mock/user/database/database.go
+++ b/api/mock/user/database/database.go
@@ -65,6 +65,20 @@ func (mr *MockStudentMockRecorder) Create(ctx, s interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockStudent)(nil).Create), ctx, s)
 }
 
+// Delete mocks base method.
+func (m *MockStudent) Delete(ctx context.Context, studentID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", ctx, studentID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockStudentMockRecorder) Delete(ctx, studentID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStudent)(nil).Delete), ctx, studentID)
+}
+
 // Get mocks base method.
 func (m *MockStudent) Get(ctx context.Context, id string, fields ...string) (*entity.Student, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## やったこと
interfaceにDeleteStudentを追加
メソッドの詳細、テスト

### レビュー時のポイント

## 残タスク
usecase層

## 備考
