### PR TITLE
fix(web/teacher): fix create shift dialog

### DIFF
--- a/web/teacher/src/components/organisms/TheShiftEditCard.vue
+++ b/web/teacher/src/components/organisms/TheShiftEditCard.vue
@@ -10,7 +10,7 @@
         <v-row v-else class="py-8">
           <v-col cols="12">
             <h4>シフト提出可能期間</h4>
-            <div class="d-flex">
+            <div class="d-flex align-center">
               <the-date-picker
                 :label="form.options.openDate.label"
                 :rules="form.options.openDate.rules"

--- a/web/teacher/src/components/organisms/TheShiftNewCard.vue
+++ b/web/teacher/src/components/organisms/TheShiftNewCard.vue
@@ -16,7 +16,7 @@
           </v-col>
           <v-col cols="12">
             <h4>シフト提出可能期間</h4>
-            <div class="d-flex">
+            <div class="d-flex align-center">
               <the-date-picker
                 :label="form.options.openDate.label"
                 :rules="form.options.openDate.rules"
@@ -34,16 +34,17 @@
             <h4>
               <span class="pr-4">休日の設定</span>
               <v-btn color="primary" fab x-small @click="addClosedDate"><v-icon>mdi-plus</v-icon></v-btn>
-              <div v-for="(_, index) in form.params.closedDates" :key="index" class="d-flex flex-column">
-                <the-date-picker
-                  :label="form.options.closedDates.label"
-                  :rules="form.options.closedDates.rules"
-                  :value.sync="form.params.closedDates[index]"
-                >
-                  <v-btn color="error" fab x-small @click="removeClosedDate(index)"><v-icon>mdi-minus</v-icon></v-btn>
-                </the-date-picker>
-              </div>
             </h4>
+            <the-date-picker
+              v-for="(_, index) in form.params.closedDates"
+              :key="index"
+              :label="form.options.closedDates.label"
+              :rules="form.options.closedDates.rules"
+              :value.sync="form.params.closedDates[index]"
+              class="d-flex flex-column"
+            >
+              <v-btn color="error" fab x-small @click="removeClosedDate(index)"><v-icon>mdi-minus</v-icon></v-btn>
+            </the-date-picker>
           </v-col>
         </v-row>
       </the-form-group>


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
シフト作成ダイアログにて、 `h4` タグの付与箇所が誤っていたので修正しました。
併せて、期間指定の入力フォームのUIの微調整 ( `~` の位置を中央寄せ) にする修正もしています。

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
