### PR TITLE
feat(lesson-api): implement list lessons api

### DIFF
--- a/api/internal/lesson/api/lesson.go
+++ b/api/internal/lesson/api/lesson.go
@@ -32,6 +32,50 @@ func (s *lessonService) ListLessonsByShiftSummaryID(
 	return res, nil
 }
 
+func (s *lessonService) ListLessonsByTeacherID(
+	ctx context.Context, req *lesson.ListLessonsByTeacherIDRequest,
+) (*lesson.ListLessonsByTeacherIDResponse, error) {
+	if err := s.validator.ListLessonsByTeacherID(req); err != nil {
+		return nil, gRPCError(err)
+	}
+
+	params := &database.ListLessonsParams{
+		ShiftSummaryID: req.ShiftSummaryId,
+		TeacherID:      req.TeacherId,
+	}
+	lessons, err := s.db.Lesson.List(ctx, params)
+	if err != nil {
+		return nil, gRPCError(err)
+	}
+
+	res := &lesson.ListLessonsByTeacherIDResponse{
+		Lessons: lessons.Proto(),
+	}
+	return res, nil
+}
+
+func (s *lessonService) ListLessonsByStudentID(
+	ctx context.Context, req *lesson.ListLessonsByStudentIDRequest,
+) (*lesson.ListLessonsByStudentIDResponse, error) {
+	if err := s.validator.ListLessonsByStudentID(req); err != nil {
+		return nil, gRPCError(err)
+	}
+
+	params := &database.ListLessonsParams{
+		ShiftSummaryID: req.ShiftSummaryId,
+		StudentID:      req.StudentId,
+	}
+	lessons, err := s.db.Lesson.List(ctx, params)
+	if err != nil {
+		return nil, gRPCError(err)
+	}
+
+	res := &lesson.ListLessonsByStudentIDResponse{
+		Lessons: lessons.Proto(),
+	}
+	return res, nil
+}
+
 func (s *lessonService) CreateLesson(
 	ctx context.Context, req *lesson.CreateLessonRequest,
 ) (*lesson.CreateLessonResponse, error) {

--- a/api/internal/lesson/api/lesson_test.go
+++ b/api/internal/lesson/api/lesson_test.go
@@ -106,6 +106,186 @@ func TestListLessonsByShiftSummaryID(t *testing.T) {
 	}
 }
 
+func TestListLessonsByTeacherID(t *testing.T) {
+	t.Parallel()
+
+	now := jst.Now()
+	req := &lesson.ListLessonsByTeacherIDRequest{
+		ShiftSummaryId: 1,
+		TeacherId:      "teacherid",
+	}
+	lessons := entity.Lessons{
+		{
+			ID:             1,
+			ShiftSummaryID: 1,
+			ShiftID:        1,
+			SubjectID:      1,
+			RoomID:         1,
+			TeacherID:      "teacherid",
+			StudentID:      "studentid",
+			Notes:          "",
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		},
+	}
+
+	tests := []struct {
+		name   string
+		setup  func(ctx context.Context, t *testing.T, mocks *mocks)
+		req    *lesson.ListLessonsByTeacherIDRequest
+		expect *testResponse
+	}{
+		{
+			name: "success",
+			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
+				params := &database.ListLessonsParams{ShiftSummaryID: 1, TeacherID: "teacherid"}
+				mocks.validator.EXPECT().ListLessonsByTeacherID(req).Return(nil)
+				mocks.db.Lesson.EXPECT().List(ctx, params).Return(lessons, nil)
+			},
+			req: req,
+			expect: &testResponse{
+				code: codes.OK,
+				body: &lesson.ListLessonsByTeacherIDResponse{
+					Lessons: []*lesson.Lesson{
+						{
+							Id:             1,
+							ShiftSummaryId: 1,
+							ShiftId:        1,
+							SubjectId:      1,
+							RoomId:         1,
+							TeacherId:      "teacherid",
+							StudentId:      "studentid",
+							Notes:          "",
+							CreatedAt:      now.Unix(),
+							UpdatedAt:      now.Unix(),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "invalid argument",
+			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
+				req := &lesson.ListLessonsByTeacherIDRequest{}
+				mocks.validator.EXPECT().ListLessonsByTeacherID(req).Return(validation.ErrRequestValidation)
+			},
+			req: &lesson.ListLessonsByTeacherIDRequest{},
+			expect: &testResponse{
+				code: codes.InvalidArgument,
+			},
+		},
+		{
+			name: "failed to list lessons",
+			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
+				params := &database.ListLessonsParams{ShiftSummaryID: 1, TeacherID: "teacherid"}
+				mocks.validator.EXPECT().ListLessonsByTeacherID(req).Return(nil)
+				mocks.db.Lesson.EXPECT().List(ctx, params).Return(nil, errmock)
+			},
+			req: req,
+			expect: &testResponse{
+				code: codes.Internal,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, testGRPC(tt.setup, tt.expect, func(ctx context.Context, service *lessonService) (proto.Message, error) {
+			return service.ListLessonsByTeacherID(ctx, tt.req)
+		}))
+	}
+}
+
+func TestListLessonsByStudentID(t *testing.T) {
+	t.Parallel()
+
+	now := jst.Now()
+	req := &lesson.ListLessonsByStudentIDRequest{
+		ShiftSummaryId: 1,
+		StudentId:      "studentid",
+	}
+	lessons := entity.Lessons{
+		{
+			ID:             1,
+			ShiftSummaryID: 1,
+			ShiftID:        1,
+			SubjectID:      1,
+			RoomID:         1,
+			TeacherID:      "teacherid",
+			StudentID:      "studentid",
+			Notes:          "",
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		},
+	}
+
+	tests := []struct {
+		name   string
+		setup  func(ctx context.Context, t *testing.T, mocks *mocks)
+		req    *lesson.ListLessonsByStudentIDRequest
+		expect *testResponse
+	}{
+		{
+			name: "success",
+			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
+				params := &database.ListLessonsParams{ShiftSummaryID: 1, StudentID: "studentid"}
+				mocks.validator.EXPECT().ListLessonsByStudentID(req).Return(nil)
+				mocks.db.Lesson.EXPECT().List(ctx, params).Return(lessons, nil)
+			},
+			req: req,
+			expect: &testResponse{
+				code: codes.OK,
+				body: &lesson.ListLessonsByStudentIDResponse{
+					Lessons: []*lesson.Lesson{
+						{
+							Id:             1,
+							ShiftSummaryId: 1,
+							ShiftId:        1,
+							SubjectId:      1,
+							RoomId:         1,
+							TeacherId:      "teacherid",
+							StudentId:      "studentid",
+							Notes:          "",
+							CreatedAt:      now.Unix(),
+							UpdatedAt:      now.Unix(),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "invalid argument",
+			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
+				req := &lesson.ListLessonsByStudentIDRequest{}
+				mocks.validator.EXPECT().ListLessonsByStudentID(req).Return(validation.ErrRequestValidation)
+			},
+			req: &lesson.ListLessonsByStudentIDRequest{},
+			expect: &testResponse{
+				code: codes.InvalidArgument,
+			},
+		},
+		{
+			name: "failed to list lessons",
+			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
+				params := &database.ListLessonsParams{ShiftSummaryID: 1, StudentID: "studentid"}
+				mocks.validator.EXPECT().ListLessonsByStudentID(req).Return(nil)
+				mocks.db.Lesson.EXPECT().List(ctx, params).Return(nil, errmock)
+			},
+			req: req,
+			expect: &testResponse{
+				code: codes.Internal,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, testGRPC(tt.setup, tt.expect, func(ctx context.Context, service *lessonService) (proto.Message, error) {
+			return service.ListLessonsByStudentID(ctx, tt.req)
+		}))
+	}
+}
+
 func TestCreateLesson(t *testing.T) {
 	t.Parallel()
 

--- a/api/internal/lesson/database/database.go
+++ b/api/internal/lesson/database/database.go
@@ -120,6 +120,8 @@ type ListLessonsParams struct {
 	Limit          int
 	Offset         int
 	ShiftSummaryID int64
+	TeacherID      string
+	StudentID      string
 }
 
 type ListShiftSummariesParams struct {

--- a/api/internal/lesson/database/lesson.go
+++ b/api/internal/lesson/database/lesson.go
@@ -38,6 +38,12 @@ func (l *lesson) List(ctx context.Context, params *ListLessonsParams, fields ...
 	if params.ShiftSummaryID > 0 {
 		stmt.Where("shift_summary_id = ?", params.ShiftSummaryID)
 	}
+	if params.TeacherID != "" {
+		stmt.Where("teacher_id = ?", params.TeacherID)
+	}
+	if params.StudentID != "" {
+		stmt.Where("student_id = ?", params.StudentID)
+	}
 	if params.Limit > 0 {
 		stmt.Limit(params.Limit)
 	}

--- a/api/internal/lesson/database/lesson_test.go
+++ b/api/internal/lesson/database/lesson_test.go
@@ -71,6 +71,8 @@ func TestLesson_List(t *testing.T) {
 			args: args{
 				params: &ListLessonsParams{
 					ShiftSummaryID: 100,
+					TeacherID:      "teacherid",
+					StudentID:      "studentid",
 					Limit:          1,
 					Offset:         100,
 				},

--- a/api/internal/lesson/validation/lesson.go
+++ b/api/internal/lesson/validation/lesson.go
@@ -11,6 +11,24 @@ func (v *requestValidation) ListLessonsByShiftSummaryID(req *lesson.ListLessonsB
 	return nil
 }
 
+func (v *requestValidation) ListLessonsByTeacherID(req *lesson.ListLessonsByTeacherIDRequest) error {
+	if err := req.Validate(); err != nil {
+		validate := err.(lesson.ListLessonsByTeacherIDRequestValidationError)
+		return validationError(validate.Error())
+	}
+
+	return nil
+}
+
+func (v *requestValidation) ListLessonsByStudentID(req *lesson.ListLessonsByStudentIDRequest) error {
+	if err := req.Validate(); err != nil {
+		validate := err.(lesson.ListLessonsByStudentIDRequestValidationError)
+		return validationError(validate.Error())
+	}
+
+	return nil
+}
+
 func (v *requestValidation) CreateLesson(req *lesson.CreateLessonRequest) error {
 	if err := req.Validate(); err != nil {
 		validate := err.(lesson.CreateLessonRequestValidationError)

--- a/api/internal/lesson/validation/lesson_test.go
+++ b/api/internal/lesson/validation/lesson_test.go
@@ -43,6 +43,96 @@ func TestListLessonsByShiftSummaryID(t *testing.T) {
 	}
 }
 
+func TestListLessonsByTeacherID(t *testing.T) {
+	t.Parallel()
+	validator := NewRequestValidation()
+
+	tests := []struct {
+		name  string
+		req   *lesson.ListLessonsByTeacherIDRequest
+		isErr bool
+	}{
+		{
+			name: "success",
+			req: &lesson.ListLessonsByTeacherIDRequest{
+				ShiftSummaryId: 1,
+				TeacherId:      "teacherid",
+			},
+			isErr: false,
+		},
+		{
+			name: "ShiftSummaryId is gt",
+			req: &lesson.ListLessonsByTeacherIDRequest{
+				ShiftSummaryId: 0,
+				TeacherId:      "teacherid",
+			},
+			isErr: true,
+		},
+		{
+			name: "TeacherId is min_len",
+			req: &lesson.ListLessonsByTeacherIDRequest{
+				ShiftSummaryId: 1,
+				TeacherId:      "",
+			},
+			isErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validator.ListLessonsByTeacherID(tt.req)
+			assert.Equal(t, tt.isErr, err != nil, err)
+		})
+	}
+}
+
+func TestListLessonsByStudentID(t *testing.T) {
+	t.Parallel()
+	validator := NewRequestValidation()
+
+	tests := []struct {
+		name  string
+		req   *lesson.ListLessonsByStudentIDRequest
+		isErr bool
+	}{
+		{
+			name: "success",
+			req: &lesson.ListLessonsByStudentIDRequest{
+				ShiftSummaryId: 1,
+				StudentId:      "studentid",
+			},
+			isErr: false,
+		},
+		{
+			name: "ShiftSummaryId is gt",
+			req: &lesson.ListLessonsByStudentIDRequest{
+				ShiftSummaryId: 0,
+				StudentId:      "studentid",
+			},
+			isErr: true,
+		},
+		{
+			name: "StudentId is min_len",
+			req: &lesson.ListLessonsByStudentIDRequest{
+				ShiftSummaryId: 1,
+				StudentId:      "",
+			},
+			isErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validator.ListLessonsByStudentID(tt.req)
+			assert.Equal(t, tt.isErr, err != nil, err)
+		})
+	}
+}
+
 func TestCreateLesson(t *testing.T) {
 	t.Parallel()
 	validator := NewRequestValidation()

--- a/api/internal/lesson/validation/validator.go
+++ b/api/internal/lesson/validation/validator.go
@@ -13,6 +13,8 @@ var ErrRequestValidation = errors.New("validation: invalid argument")
 
 type RequestValidation interface {
 	ListLessonsByShiftSummaryID(req *lesson.ListLessonsByShiftSummaryIDRequest) error
+	ListLessonsByTeacherID(req *lesson.ListLessonsByTeacherIDRequest) error
+	ListLessonsByStudentID(req *lesson.ListLessonsByStudentIDRequest) error
 	CreateLesson(req *lesson.CreateLessonRequest) error
 	ListShiftSummaries(req *lesson.ListShiftSummariesRequest) error
 	GetShiftSummary(req *lesson.GetShiftSummaryRequest) error

--- a/api/mock/lesson/validation/validator.go
+++ b/api/mock/lesson/validation/validator.go
@@ -132,6 +132,34 @@ func (mr *MockRequestValidationMockRecorder) ListLessonsByShiftSummaryID(req int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLessonsByShiftSummaryID", reflect.TypeOf((*MockRequestValidation)(nil).ListLessonsByShiftSummaryID), req)
 }
 
+// ListLessonsByStudentID mocks base method.
+func (m *MockRequestValidation) ListLessonsByStudentID(req *lesson.ListLessonsByStudentIDRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListLessonsByStudentID", req)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ListLessonsByStudentID indicates an expected call of ListLessonsByStudentID.
+func (mr *MockRequestValidationMockRecorder) ListLessonsByStudentID(req interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLessonsByStudentID", reflect.TypeOf((*MockRequestValidation)(nil).ListLessonsByStudentID), req)
+}
+
+// ListLessonsByTeacherID mocks base method.
+func (m *MockRequestValidation) ListLessonsByTeacherID(req *lesson.ListLessonsByTeacherIDRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListLessonsByTeacherID", req)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ListLessonsByTeacherID indicates an expected call of ListLessonsByTeacherID.
+func (mr *MockRequestValidationMockRecorder) ListLessonsByTeacherID(req interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLessonsByTeacherID", reflect.TypeOf((*MockRequestValidation)(nil).ListLessonsByTeacherID), req)
+}
+
 // ListShiftSummaries mocks base method.
 func (m *MockRequestValidation) ListShiftSummaries(req *lesson.ListShiftSummariesRequest) error {
 	m.ctrl.T.Helper()

--- a/api/mock/proto/lesson/service_grpc.pb.go.go
+++ b/api/mock/proto/lesson/service_grpc.pb.go.go
@@ -176,6 +176,46 @@ func (mr *MockLessonServiceClientMockRecorder) ListLessonsByShiftSummaryID(ctx, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLessonsByShiftSummaryID", reflect.TypeOf((*MockLessonServiceClient)(nil).ListLessonsByShiftSummaryID), varargs...)
 }
 
+// ListLessonsByStudentID mocks base method.
+func (m *MockLessonServiceClient) ListLessonsByStudentID(ctx context.Context, in *lesson.ListLessonsByStudentIDRequest, opts ...grpc.CallOption) (*lesson.ListLessonsByStudentIDResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListLessonsByStudentID", varargs...)
+	ret0, _ := ret[0].(*lesson.ListLessonsByStudentIDResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListLessonsByStudentID indicates an expected call of ListLessonsByStudentID.
+func (mr *MockLessonServiceClientMockRecorder) ListLessonsByStudentID(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLessonsByStudentID", reflect.TypeOf((*MockLessonServiceClient)(nil).ListLessonsByStudentID), varargs...)
+}
+
+// ListLessonsByTeacherID mocks base method.
+func (m *MockLessonServiceClient) ListLessonsByTeacherID(ctx context.Context, in *lesson.ListLessonsByTeacherIDRequest, opts ...grpc.CallOption) (*lesson.ListLessonsByTeacherIDResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListLessonsByTeacherID", varargs...)
+	ret0, _ := ret[0].(*lesson.ListLessonsByTeacherIDResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListLessonsByTeacherID indicates an expected call of ListLessonsByTeacherID.
+func (mr *MockLessonServiceClientMockRecorder) ListLessonsByTeacherID(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLessonsByTeacherID", reflect.TypeOf((*MockLessonServiceClient)(nil).ListLessonsByTeacherID), varargs...)
+}
+
 // ListShiftSummaries mocks base method.
 func (m *MockLessonServiceClient) ListShiftSummaries(ctx context.Context, in *lesson.ListShiftSummariesRequest, opts ...grpc.CallOption) (*lesson.ListShiftSummariesResponse, error) {
 	m.ctrl.T.Helper()
@@ -502,6 +542,36 @@ func (m *MockLessonServiceServer) ListLessonsByShiftSummaryID(arg0 context.Conte
 func (mr *MockLessonServiceServerMockRecorder) ListLessonsByShiftSummaryID(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLessonsByShiftSummaryID", reflect.TypeOf((*MockLessonServiceServer)(nil).ListLessonsByShiftSummaryID), arg0, arg1)
+}
+
+// ListLessonsByStudentID mocks base method.
+func (m *MockLessonServiceServer) ListLessonsByStudentID(arg0 context.Context, arg1 *lesson.ListLessonsByStudentIDRequest) (*lesson.ListLessonsByStudentIDResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListLessonsByStudentID", arg0, arg1)
+	ret0, _ := ret[0].(*lesson.ListLessonsByStudentIDResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListLessonsByStudentID indicates an expected call of ListLessonsByStudentID.
+func (mr *MockLessonServiceServerMockRecorder) ListLessonsByStudentID(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLessonsByStudentID", reflect.TypeOf((*MockLessonServiceServer)(nil).ListLessonsByStudentID), arg0, arg1)
+}
+
+// ListLessonsByTeacherID mocks base method.
+func (m *MockLessonServiceServer) ListLessonsByTeacherID(arg0 context.Context, arg1 *lesson.ListLessonsByTeacherIDRequest) (*lesson.ListLessonsByTeacherIDResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListLessonsByTeacherID", arg0, arg1)
+	ret0, _ := ret[0].(*lesson.ListLessonsByTeacherIDResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListLessonsByTeacherID indicates an expected call of ListLessonsByTeacherID.
+func (mr *MockLessonServiceServerMockRecorder) ListLessonsByTeacherID(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLessonsByTeacherID", reflect.TypeOf((*MockLessonServiceServer)(nil).ListLessonsByTeacherID), arg0, arg1)
 }
 
 // ListShiftSummaries mocks base method.

--- a/api/proto/lesson/service.proto
+++ b/api/proto/lesson/service.proto
@@ -17,6 +17,8 @@ import "lesson/student_shift.proto";
 
 service LessonService {
   rpc ListLessonsByShiftSummaryID(ListLessonsByShiftSummaryIDRequest) returns (ListLessonsByShiftSummaryIDResponse);
+  rpc ListLessonsByTeacherID(ListLessonsByTeacherIDRequest) returns (ListLessonsByTeacherIDResponse);
+  rpc ListLessonsByStudentID(ListLessonsByStudentIDRequest) returns (ListLessonsByStudentIDResponse);
   rpc CreateLesson(CreateLessonRequest) returns (CreateLessonResponse);
   rpc ListShiftSummaries(ListShiftSummariesRequest) returns (ListShiftSummariesResponse);
   rpc GetShiftSummary(GetShiftSummaryRequest) returns (GetShiftSummaryResponse);
@@ -40,6 +42,24 @@ message ListLessonsByShiftSummaryIDRequest {
 }
 
 message ListLessonsByShiftSummaryIDResponse {
+  repeated Lesson lessons = 1;
+}
+
+message ListLessonsByTeacherIDRequest {
+  int64  shift_summary_id = 1 [(validate.rules).int64 = { gt: 0 }];
+  string teacher_id       = 2 [(validate.rules).string = { min_len: 1 }];
+}
+
+message ListLessonsByTeacherIDResponse {
+  repeated Lesson lessons = 1;
+}
+
+message ListLessonsByStudentIDRequest {
+  int64  shift_summary_id = 1 [(validate.rules).int64 = { gt: 0 }];
+  string student_id       = 2 [(validate.rules).string = { min_len: 1 }];
+}
+
+message ListLessonsByStudentIDResponse {
   repeated Lesson lessons = 1;
 }
 


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
講師ID, 生徒IDベースで授業一覧を取得するためのAPIを実装しました

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
