### PR TITLE
Feat/lesson api/implement list submissions

### DIFF
--- a/api/internal/lesson/database/database.go
+++ b/api/internal/lesson/database/database.go
@@ -85,6 +85,7 @@ type TeacherShift interface {
 	ListByShiftSummaryID(
 		ctx context.Context, teacherIDs []string, summaryID int64, fields ...string,
 	) (entity.TeacherShifts, error)
+	ListByShiftID(ctx context.Context, shiftID int64, fields ...string) (entity.TeacherShifts, error)
 	Replace(ctx context.Context, submission *entity.TeacherSubmission, shifts entity.TeacherShifts) error
 }
 
@@ -102,6 +103,7 @@ type StudentShift interface {
 	ListByShiftSummaryID(
 		ctx context.Context, studentIDs []string, summaryID int64, fields ...string,
 	) (entity.StudentShifts, error)
+	ListByShiftID(ctx context.Context, shiftID int64, fields ...string) (entity.StudentShifts, error)
 	Replace(ctx context.Context, submission *entity.StudentSubmission, shifts entity.StudentShifts) error
 }
 

--- a/api/internal/lesson/database/student_shift.go
+++ b/api/internal/lesson/database/student_shift.go
@@ -46,6 +46,21 @@ func (s *studentShift) ListByShiftSummaryID(
 	return shifts, dbError(err)
 }
 
+func (s *studentShift) ListByShiftID(
+	ctx context.Context, shiftID int64, fields ...string,
+) (entity.StudentShifts, error) {
+	var shifts entity.StudentShifts
+	if len(fields) == 0 {
+		fields = studentShiftFields
+	}
+
+	stmt := s.db.DB.Table(studentShiftTable).Select(fields).
+		Where("shift_id = ?", shiftID)
+
+	err := stmt.Find(&shifts).Error
+	return shifts, dbError(err)
+}
+
 func (s *studentShift) Replace(
 	ctx context.Context, submission *entity.StudentSubmission, shifts entity.StudentShifts,
 ) error {

--- a/api/internal/lesson/database/student_shift_test.go
+++ b/api/internal/lesson/database/student_shift_test.go
@@ -96,6 +96,89 @@ func TestStudentShift_ListByShiftSummaryID(t *testing.T) {
 	}
 }
 
+func TestStudentShift_ListByShiftID(t *testing.T) {
+	m, err := newMock()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_ = m.dbDelete(ctx, studentShiftTable, studentSubmissionTable, shiftTable, shiftSummaryTable)
+
+	now := jst.Date(2021, 12, 10, 12, 0, 0, 0)
+
+	const studentID = "studentid"
+	var openAt, endAt = jst.Date(2021, 12, 1, 0, 0, 0, 0), jst.Date(2021, 12, 15, 0, 0, 0, 0)
+	summary := testShiftSummary(1, 2022, openAt, endAt, now)
+	err = m.db.DB.Create(&summary).Error
+	require.NoError(t, err)
+
+	shifts := make(entity.Shifts, 5)
+	shifts[0] = testShift(1, 1, jst.Date(2022, 1, 1, 0, 0, 0, 0), "1700", "1830", now)
+	shifts[1] = testShift(2, 1, jst.Date(2022, 1, 1, 0, 0, 0, 0), "1830", "2000", now)
+	shifts[2] = testShift(3, 1, jst.Date(2022, 1, 2, 0, 0, 0, 0), "1700", "1830", now)
+	shifts[3] = testShift(4, 1, jst.Date(2022, 1, 2, 0, 0, 0, 0), "1830", "2000", now)
+	shifts[4] = testShift(5, 1, jst.Date(2022, 1, 2, 0, 0, 0, 0), "2000", "2130", now)
+	err = m.db.DB.Create(&shifts).Error
+	require.NoError(t, err)
+
+	submission := testStudentSubmission(studentID, 1, true, now)
+	err = m.db.DB.Create(&submission).Error
+	require.NoError(t, err)
+
+	studentShifts := make(entity.StudentShifts, 3)
+	studentShifts[0] = testStudentShift(studentID, 1, 1, now)
+	studentShifts[1] = testStudentShift(studentID, 1, 2, now)
+	studentShifts[2] = testStudentShift(studentID, 1, 4, now)
+	err = m.db.DB.Create(&studentShifts).Error
+	require.NoError(t, err)
+
+	type args struct {
+		shiftID int64
+	}
+	type want struct {
+		shifts entity.StudentShifts
+		isErr  bool
+	}
+	tests := []struct {
+		name  string
+		setup func(ctx context.Context, t *testing.T, m *mocks)
+		args  args
+		want  want
+	}{
+		{
+			name:  "success",
+			setup: func(ctx context.Context, t *testing.T, m *mocks) {},
+			args: args{
+				shiftID: 1,
+			},
+			want: want{
+				shifts: studentShifts[:1],
+				isErr:  false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			tt.setup(ctx, t, m)
+
+			db := NewStudentShift(m.db)
+			actual, err := db.ListByShiftID(ctx, tt.args.shiftID)
+			assert.Equal(t, tt.want.isErr, err != nil, err)
+			assert.Len(t, actual, len(tt.want.shifts))
+			for i, shift := range tt.want.shifts {
+				shift.CreatedAt, shift.UpdatedAt = actual[i].CreatedAt, actual[i].UpdatedAt
+				assert.Contains(t, actual, shift)
+			}
+		})
+	}
+}
+
 func TestStudentShift_Replace(t *testing.T) {
 	m, err := newMock()
 	require.NoError(t, err)

--- a/api/internal/lesson/database/teacher_shift.go
+++ b/api/internal/lesson/database/teacher_shift.go
@@ -46,6 +46,21 @@ func (s *teacherShift) ListByShiftSummaryID(
 	return shifts, dbError(err)
 }
 
+func (s *teacherShift) ListByShiftID(
+	ctx context.Context, shiftID int64, fields ...string,
+) (entity.TeacherShifts, error) {
+	var shifts entity.TeacherShifts
+	if len(fields) == 0 {
+		fields = teacherShiftFields
+	}
+
+	stmt := s.db.DB.Table(teacherShiftTable).Select(fields).
+		Where("shift_id = ?", shiftID)
+
+	err := stmt.Find(&shifts).Error
+	return shifts, dbError(err)
+}
+
 func (s *teacherShift) Replace(
 	ctx context.Context, submission *entity.TeacherSubmission, shifts entity.TeacherShifts,
 ) error {

--- a/api/internal/lesson/database/teacher_shift_test.go
+++ b/api/internal/lesson/database/teacher_shift_test.go
@@ -96,6 +96,89 @@ func TestTeacherShift_ListByShiftSummaryID(t *testing.T) {
 	}
 }
 
+func TestTeacherShift_ListByShiftID(t *testing.T) {
+	m, err := newMock()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_ = m.dbDelete(ctx, teacherShiftTable, teacherSubmissionTable, shiftTable, shiftSummaryTable)
+
+	now := jst.Date(2021, 12, 10, 12, 0, 0, 0)
+
+	const teacherID = "teacherid"
+	var openAt, endAt = jst.Date(2021, 12, 1, 0, 0, 0, 0), jst.Date(2021, 12, 15, 0, 0, 0, 0)
+	summary := testShiftSummary(1, 2022, openAt, endAt, now)
+	err = m.db.DB.Create(&summary).Error
+	require.NoError(t, err)
+
+	shifts := make(entity.Shifts, 5)
+	shifts[0] = testShift(1, 1, jst.Date(2022, 1, 1, 0, 0, 0, 0), "1700", "1830", now)
+	shifts[1] = testShift(2, 1, jst.Date(2022, 1, 1, 0, 0, 0, 0), "1830", "2000", now)
+	shifts[2] = testShift(3, 1, jst.Date(2022, 1, 2, 0, 0, 0, 0), "1700", "1830", now)
+	shifts[3] = testShift(4, 1, jst.Date(2022, 1, 2, 0, 0, 0, 0), "1830", "2000", now)
+	shifts[4] = testShift(5, 1, jst.Date(2022, 1, 2, 0, 0, 0, 0), "2000", "2130", now)
+	err = m.db.DB.Create(&shifts).Error
+	require.NoError(t, err)
+
+	submission := testTeacherSubmission(teacherID, 1, true, now)
+	err = m.db.DB.Create(&submission).Error
+	require.NoError(t, err)
+
+	teacherShifts := make(entity.TeacherShifts, 3)
+	teacherShifts[0] = testTeacherShift(teacherID, 1, 1, now)
+	teacherShifts[1] = testTeacherShift(teacherID, 1, 2, now)
+	teacherShifts[2] = testTeacherShift(teacherID, 1, 4, now)
+	err = m.db.DB.Create(&teacherShifts).Error
+	require.NoError(t, err)
+
+	type args struct {
+		shiftID int64
+	}
+	type want struct {
+		shifts entity.TeacherShifts
+		isErr  bool
+	}
+	tests := []struct {
+		name  string
+		setup func(ctx context.Context, t *testing.T, m *mocks)
+		args  args
+		want  want
+	}{
+		{
+			name:  "success",
+			setup: func(ctx context.Context, t *testing.T, m *mocks) {},
+			args: args{
+				shiftID: 1,
+			},
+			want: want{
+				shifts: teacherShifts[:1],
+				isErr:  false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			tt.setup(ctx, t, m)
+
+			db := NewTeacherShift(m.db)
+			actual, err := db.ListByShiftID(ctx, tt.args.shiftID)
+			assert.Equal(t, tt.want.isErr, err != nil, err)
+			assert.Len(t, actual, len(tt.want.shifts))
+			for i, shift := range tt.want.shifts {
+				shift.CreatedAt, shift.UpdatedAt = actual[i].CreatedAt, actual[i].UpdatedAt
+				assert.Contains(t, actual, shift)
+			}
+		})
+	}
+}
+
 func TestTeacherShift_Replace(t *testing.T) {
 	m, err := newMock()
 	require.NoError(t, err)

--- a/api/internal/lesson/validation/shift.go
+++ b/api/internal/lesson/validation/shift.go
@@ -55,3 +55,12 @@ func (v *requestValidation) CreateShifts(req *lesson.CreateShiftsRequest) error 
 
 	return nil
 }
+
+func (v *requestValidation) ListSubmissions(req *lesson.ListSubmissionsRequest) error {
+	if err := req.Validate(); err != nil {
+		validate := err.(lesson.ListSubmissionsRequestValidationError)
+		return validationError(validate.Error())
+	}
+
+	return nil
+}

--- a/api/internal/lesson/validation/shift_test.go
+++ b/api/internal/lesson/validation/shift_test.go
@@ -341,3 +341,38 @@ func TestCreateShifts(t *testing.T) {
 		})
 	}
 }
+
+func TestListSubmissions(t *testing.T) {
+	t.Parallel()
+	validator := NewRequestValidation()
+
+	tests := []struct {
+		name  string
+		req   *lesson.ListSubmissionsRequest
+		isErr bool
+	}{
+		{
+			name: "success",
+			req: &lesson.ListSubmissionsRequest{
+				ShiftId: 1,
+			},
+			isErr: false,
+		},
+		{
+			name: "Id is gt",
+			req: &lesson.ListSubmissionsRequest{
+				ShiftId: 0,
+			},
+			isErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validator.ListSubmissions(tt.req)
+			assert.Equal(t, tt.isErr, err != nil, err)
+		})
+	}
+}

--- a/api/internal/lesson/validation/validator.go
+++ b/api/internal/lesson/validation/validator.go
@@ -22,6 +22,7 @@ type RequestValidation interface {
 	DeleteShiftSummary(req *lesson.DeleteShiftSummaryRequest) error
 	ListShifts(req *lesson.ListShiftsRequest) error
 	CreateShifts(req *lesson.CreateShiftsRequest) error
+	ListSubmissions(req *lesson.ListSubmissionsRequest) error
 	ListTeacherSubmissionsByShiftSummaryIDs(req *lesson.ListTeacherSubmissionsByShiftSummaryIDsRequest) error
 	ListTeacherShifts(req *lesson.ListTeacherShiftsRequest) error
 	GetTeacherShifts(req *lesson.GetTeacherShiftsRequest) error

--- a/api/mock/lesson/database/database.go
+++ b/api/mock/lesson/database/database.go
@@ -388,6 +388,26 @@ func (m *MockTeacherShift) EXPECT() *MockTeacherShiftMockRecorder {
 	return m.recorder
 }
 
+// ListByShiftID mocks base method.
+func (m *MockTeacherShift) ListByShiftID(ctx context.Context, shiftID int64, fields ...string) (entity.TeacherShifts, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, shiftID}
+	for _, a := range fields {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListByShiftID", varargs...)
+	ret0, _ := ret[0].(entity.TeacherShifts)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListByShiftID indicates an expected call of ListByShiftID.
+func (mr *MockTeacherShiftMockRecorder) ListByShiftID(ctx, shiftID interface{}, fields ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, shiftID}, fields...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByShiftID", reflect.TypeOf((*MockTeacherShift)(nil).ListByShiftID), varargs...)
+}
+
 // ListByShiftSummaryID mocks base method.
 func (m *MockTeacherShift) ListByShiftSummaryID(ctx context.Context, teacherIDs []string, summaryID int64, fields ...string) (entity.TeacherShifts, error) {
 	m.ctrl.T.Helper()
@@ -526,6 +546,26 @@ func NewMockStudentShift(ctrl *gomock.Controller) *MockStudentShift {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockStudentShift) EXPECT() *MockStudentShiftMockRecorder {
 	return m.recorder
+}
+
+// ListByShiftID mocks base method.
+func (m *MockStudentShift) ListByShiftID(ctx context.Context, shiftID int64, fields ...string) (entity.StudentShifts, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, shiftID}
+	for _, a := range fields {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListByShiftID", varargs...)
+	ret0, _ := ret[0].(entity.StudentShifts)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListByShiftID indicates an expected call of ListByShiftID.
+func (mr *MockStudentShiftMockRecorder) ListByShiftID(ctx, shiftID interface{}, fields ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, shiftID}, fields...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByShiftID", reflect.TypeOf((*MockStudentShift)(nil).ListByShiftID), varargs...)
 }
 
 // ListByShiftSummaryID mocks base method.

--- a/api/mock/lesson/validation/validator.go
+++ b/api/mock/lesson/validation/validator.go
@@ -230,6 +230,20 @@ func (mr *MockRequestValidationMockRecorder) ListStudentSubmissionsByStudentIDs(
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStudentSubmissionsByStudentIDs", reflect.TypeOf((*MockRequestValidation)(nil).ListStudentSubmissionsByStudentIDs), req)
 }
 
+// ListSubmissions mocks base method.
+func (m *MockRequestValidation) ListSubmissions(req *lesson.ListSubmissionsRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListSubmissions", req)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ListSubmissions indicates an expected call of ListSubmissions.
+func (mr *MockRequestValidationMockRecorder) ListSubmissions(req interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSubmissions", reflect.TypeOf((*MockRequestValidation)(nil).ListSubmissions), req)
+}
+
 // ListTeacherShifts mocks base method.
 func (m *MockRequestValidation) ListTeacherShifts(req *lesson.ListTeacherShiftsRequest) error {
 	m.ctrl.T.Helper()

--- a/api/mock/proto/lesson/service_grpc.pb.go.go
+++ b/api/mock/proto/lesson/service_grpc.pb.go.go
@@ -316,6 +316,26 @@ func (mr *MockLessonServiceClientMockRecorder) ListStudentSubmissionsByStudentID
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStudentSubmissionsByStudentIDs", reflect.TypeOf((*MockLessonServiceClient)(nil).ListStudentSubmissionsByStudentIDs), varargs...)
 }
 
+// ListSubmissions mocks base method.
+func (m *MockLessonServiceClient) ListSubmissions(ctx context.Context, in *lesson.ListSubmissionsRequest, opts ...grpc.CallOption) (*lesson.ListSubmissionsResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListSubmissions", varargs...)
+	ret0, _ := ret[0].(*lesson.ListSubmissionsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListSubmissions indicates an expected call of ListSubmissions.
+func (mr *MockLessonServiceClientMockRecorder) ListSubmissions(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSubmissions", reflect.TypeOf((*MockLessonServiceClient)(nil).ListSubmissions), varargs...)
+}
+
 // ListTeacherShifts mocks base method.
 func (m *MockLessonServiceClient) ListTeacherShifts(ctx context.Context, in *lesson.ListTeacherShiftsRequest, opts ...grpc.CallOption) (*lesson.ListTeacherShiftsResponse, error) {
 	m.ctrl.T.Helper()
@@ -647,6 +667,21 @@ func (m *MockLessonServiceServer) ListStudentSubmissionsByStudentIDs(arg0 contex
 func (mr *MockLessonServiceServerMockRecorder) ListStudentSubmissionsByStudentIDs(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStudentSubmissionsByStudentIDs", reflect.TypeOf((*MockLessonServiceServer)(nil).ListStudentSubmissionsByStudentIDs), arg0, arg1)
+}
+
+// ListSubmissions mocks base method.
+func (m *MockLessonServiceServer) ListSubmissions(arg0 context.Context, arg1 *lesson.ListSubmissionsRequest) (*lesson.ListSubmissionsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListSubmissions", arg0, arg1)
+	ret0, _ := ret[0].(*lesson.ListSubmissionsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListSubmissions indicates an expected call of ListSubmissions.
+func (mr *MockLessonServiceServerMockRecorder) ListSubmissions(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSubmissions", reflect.TypeOf((*MockLessonServiceServer)(nil).ListSubmissions), arg0, arg1)
 }
 
 // ListTeacherShifts mocks base method.

--- a/api/proto/lesson/service.proto
+++ b/api/proto/lesson/service.proto
@@ -26,6 +26,7 @@ service LessonService {
   rpc DeleteShiftSummary(DeleteShiftSummaryRequest) returns (DeleteShiftSummaryResponse);
   rpc ListShifts(ListShiftsRequest) returns (ListShiftsResponse);
   rpc CreateShifts(CreateShiftsRequest) returns (CreateShiftsResponse);
+  rpc ListSubmissions(ListSubmissionsRequest) returns (ListSubmissionsResponse);
   rpc ListTeacherSubmissionsByShiftSummaryIDs(ListTeacherSubmissionsByShiftSummaryIDsRequest) returns (ListTeacherSubmissionsByShiftSummaryIDsResponse);
   rpc ListTeacherShifts(ListTeacherShiftsRequest) returns (ListTeacherShiftsResponse);
   rpc GetTeacherShifts(GetTeacherShiftsRequest) returns (GetTeacherShiftsResponse);
@@ -135,6 +136,15 @@ message CreateShiftsRequest {
 message CreateShiftsResponse {
   ShiftSummary   summary = 1;
   repeated Shift shifts  = 2;
+}
+
+message ListSubmissionsRequest {
+  int64 shift_id = 1 [(validate.rules).int64 = { gt: 0 }];
+}
+
+message ListSubmissionsResponse {
+  repeated TeacherShift teacher_shifts = 1;
+  repeated StudentShift student_shifts = 2;
 }
 
 message ListTeacherSubmissionsByShiftSummaryIDsRequest {


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
ShiftIdごとの出勤可能講師, 受講希望生徒それぞれの一覧取得用APIを実装しました。

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
