### PR TITLE
feat(gateway): implement list submissions api

### DIFF
--- a/api/internal/gateway/entity/student_shift.go
+++ b/api/internal/gateway/entity/student_shift.go
@@ -1,6 +1,9 @@
 package entity
 
-import "github.com/calmato/shs-web/api/proto/lesson"
+import (
+	"github.com/calmato/shs-web/api/pkg/set"
+	"github.com/calmato/shs-web/api/proto/lesson"
+)
 
 type StudentShift struct {
 	*lesson.StudentShift
@@ -20,6 +23,14 @@ func NewStudentShifts(shifts []*lesson.StudentShift) StudentShifts {
 		ss[i] = NewStudentShift(shifts[i])
 	}
 	return ss
+}
+
+func (ss StudentShifts) StudentIDs() []string {
+	set := set.New(len(ss))
+	for i := range ss {
+		set.AddStrings(ss[i].StudentId)
+	}
+	return set.Strings()
 }
 
 func (ss StudentShifts) MapByShiftID() map[int64]*StudentShift {

--- a/api/internal/gateway/entity/student_shift_test.go
+++ b/api/internal/gateway/entity/student_shift_test.go
@@ -138,7 +138,11 @@ func TestStudentShifts_StudentIDs(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.expect, tt.shifts.StudentIDs())
+			actual := tt.shifts.StudentIDs()
+			assert.Len(t, actual, len(tt.expect))
+			for i := range tt.expect {
+				assert.Contains(t, actual, tt.expect[i])
+			}
 		})
 	}
 }

--- a/api/internal/gateway/entity/student_shift_test.go
+++ b/api/internal/gateway/entity/student_shift_test.go
@@ -88,6 +88,61 @@ func TestStudentShifts(t *testing.T) {
 	}
 }
 
+func TestStudentShifts_StudentIDs(t *testing.T) {
+	t.Parallel()
+	now := jst.Now()
+	tests := []struct {
+		name   string
+		shifts StudentShifts
+		expect []string
+	}{
+		{
+			name: "success",
+			shifts: StudentShifts{
+				{
+					StudentShift: &lesson.StudentShift{
+						StudentId:      "studentid1",
+						ShiftId:        1,
+						ShiftSummaryId: 1,
+						CreatedAt:      now.Unix(),
+						UpdatedAt:      now.Unix(),
+					},
+				},
+				{
+					StudentShift: &lesson.StudentShift{
+						StudentId:      "studentid1",
+						ShiftId:        2,
+						ShiftSummaryId: 1,
+						CreatedAt:      now.Unix(),
+						UpdatedAt:      now.Unix(),
+					},
+				},
+				{
+					StudentShift: &lesson.StudentShift{
+						StudentId:      "studentid2",
+						ShiftId:        1,
+						ShiftSummaryId: 1,
+						CreatedAt:      now.Unix(),
+						UpdatedAt:      now.Unix(),
+					},
+				},
+			},
+			expect: []string{
+				"studentid1",
+				"studentid2",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.shifts.StudentIDs())
+		})
+	}
+}
+
 func TestStudentShifts_MapByShiftID(t *testing.T) {
 	t.Parallel()
 	now := jst.Now()

--- a/api/internal/gateway/entity/teacher_shift.go
+++ b/api/internal/gateway/entity/teacher_shift.go
@@ -1,6 +1,9 @@
 package entity
 
-import "github.com/calmato/shs-web/api/proto/lesson"
+import (
+	"github.com/calmato/shs-web/api/pkg/set"
+	"github.com/calmato/shs-web/api/proto/lesson"
+)
 
 type TeacherShift struct {
 	*lesson.TeacherShift
@@ -20,6 +23,14 @@ func NewTeacherShifts(shifts []*lesson.TeacherShift) TeacherShifts {
 		ss[i] = NewTeacherShift(shifts[i])
 	}
 	return ss
+}
+
+func (ss TeacherShifts) TeacherIDs() []string {
+	set := set.New(len(ss))
+	for i := range ss {
+		set.AddStrings(ss[i].TeacherId)
+	}
+	return set.Strings()
 }
 
 func (ss TeacherShifts) MapByShiftID() map[int64]*TeacherShift {

--- a/api/internal/gateway/entity/teacher_shift_test.go
+++ b/api/internal/gateway/entity/teacher_shift_test.go
@@ -138,7 +138,11 @@ func TestTeacherShifts_TeacherIDs(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.expect, tt.shifts.TeacherIDs())
+			actual := tt.shifts.TeacherIDs()
+			assert.Len(t, actual, len(tt.expect))
+			for i := range tt.expect {
+				assert.Contains(t, actual, tt.expect[i])
+			}
 		})
 	}
 }

--- a/api/internal/gateway/entity/teacher_shift_test.go
+++ b/api/internal/gateway/entity/teacher_shift_test.go
@@ -88,6 +88,61 @@ func TestTeacherShifts(t *testing.T) {
 	}
 }
 
+func TestTeacherShifts_TeacherIDs(t *testing.T) {
+	t.Parallel()
+	now := jst.Now()
+	tests := []struct {
+		name   string
+		shifts TeacherShifts
+		expect []string
+	}{
+		{
+			name: "success",
+			shifts: TeacherShifts{
+				{
+					TeacherShift: &lesson.TeacherShift{
+						TeacherId:      "teacherid1",
+						ShiftId:        1,
+						ShiftSummaryId: 1,
+						CreatedAt:      now.Unix(),
+						UpdatedAt:      now.Unix(),
+					},
+				},
+				{
+					TeacherShift: &lesson.TeacherShift{
+						TeacherId:      "teacherid1",
+						ShiftId:        2,
+						ShiftSummaryId: 1,
+						CreatedAt:      now.Unix(),
+						UpdatedAt:      now.Unix(),
+					},
+				},
+				{
+					TeacherShift: &lesson.TeacherShift{
+						TeacherId:      "teacherid2",
+						ShiftId:        1,
+						ShiftSummaryId: 1,
+						CreatedAt:      now.Unix(),
+						UpdatedAt:      now.Unix(),
+					},
+				},
+			},
+			expect: []string{
+				"teacherid1",
+				"teacherid2",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.shifts.TeacherIDs())
+		})
+	}
+}
+
 func TestTeacherShifts_MapByShiftID(t *testing.T) {
 	t.Parallel()
 	now := jst.Now()

--- a/api/internal/gateway/teacher/v1/handler/api.go
+++ b/api/internal/gateway/teacher/v1/handler/api.go
@@ -101,6 +101,7 @@ func (h *apiV1Handler) AdminRoutes(rg *gin.RouterGroup) {
 	rg.POST("/v1/shifts", h.CreateShifts)
 	rg.PATCH("/v1/shifts/:shiftId/schedule", h.UpdateShiftSummarySchedule)
 	rg.DELETE("/v1/shifts/:shiftId", h.DeleteShiftSummary)
+	rg.GET("/v1/shifts/:shiftId/submissions/:submissionId", h.ListShiftSubmissions)
 	rg.GET("/v1/shifts/:shiftId/teachers/:teacherId", h.ListEnabledTeacherShifts)
 	rg.GET("/v1/shifts/:shiftId/students/:studentId", h.ListEnabledStudentShifts)
 	rg.POST("/v1/shifts/:shiftId/lessons", h.CreateLesson)

--- a/api/internal/gateway/teacher/v1/handler/shift.go
+++ b/api/internal/gateway/teacher/v1/handler/shift.go
@@ -121,6 +121,59 @@ func (h *apiV1Handler) DeleteShiftSummary(ctx *gin.Context) {
 	ctx.JSON(http.StatusNoContent, gin.H{})
 }
 
+func (h *apiV1Handler) ListShiftSubmissions(ctx *gin.Context) {
+	c := util.SetMetadata(ctx)
+
+	shiftID, err := strconv.ParseInt(ctx.Param("submissionId"), 10, 64)
+	if err != nil {
+		badRequest(ctx, err)
+		return
+	}
+
+	in := &lesson.ListSubmissionsRequest{
+		ShiftId: shiftID,
+	}
+	out, err := h.lesson.ListSubmissions(c, in)
+	if err != nil {
+		httpError(ctx, err)
+		return
+	}
+	teacherIDs := gentity.NewTeacherShifts(out.TeacherShifts).TeacherIDs()
+	studentIDs := gentity.NewStudentShifts(out.StudentShifts).StudentIDs()
+
+	eg, ectx := errgroup.WithContext(c)
+	var gteachers gentity.Teachers
+	eg.Go(func() (err error) {
+		gteachers, err = h.multiGetTeachers(ectx, teacherIDs)
+		return
+	})
+	var gteacherSubjects map[string]gentity.Subjects
+	eg.Go(func() (err error) {
+		gteacherSubjects, err = h.multiGetTeacherSubjects(ectx, teacherIDs)
+		return
+	})
+	var gstudents gentity.Students
+	eg.Go(func() (err error) {
+		gstudents, err = h.multiGetStudents(ectx, studentIDs)
+		return
+	})
+	var gstudentSubjects map[string]gentity.Subjects
+	eg.Go(func() (err error) {
+		gstudentSubjects, err = h.multiGetStudentSubjects(ectx, studentIDs)
+		return
+	})
+	if err := eg.Wait(); err != nil {
+		httpError(ctx, err)
+		return
+	}
+
+	res := &response.ShiftSubmissionsResponse{
+		Teachers: entity.NewTeachers(gteachers, gteacherSubjects),
+		Students: entity.NewStudents(gstudents, gstudentSubjects),
+	}
+	ctx.JSON(http.StatusOK, res)
+}
+
 //nolint:funlen
 func (h *apiV1Handler) ListShifts(ctx *gin.Context) {
 	c := util.SetMetadata(ctx)

--- a/api/internal/gateway/teacher/v1/handler/shift.go
+++ b/api/internal/gateway/teacher/v1/handler/shift.go
@@ -162,14 +162,26 @@ func (h *apiV1Handler) ListShiftSubmissions(ctx *gin.Context) {
 		gstudentSubjects, err = h.multiGetStudentSubjects(ectx, studentIDs)
 		return
 	})
+	var glessons gentity.Lessons
+	var gshifts gentity.Shifts
+	eg.Go(func() (err error) {
+		// TODO: 実装
+		return
+	})
 	if err := eg.Wait(); err != nil {
 		httpError(ctx, err)
 		return
 	}
 
+	lessons, err := entity.NewLessons(glessons, gshifts.Map())
+	if err != nil {
+		httpError(ctx, err)
+		return
+	}
 	res := &response.ShiftSubmissionsResponse{
 		Teachers: entity.NewTeachers(gteachers, gteacherSubjects),
 		Students: entity.NewStudents(gstudents, gstudentSubjects),
+		Lessons:  lessons,
 	}
 	ctx.JSON(http.StatusOK, res)
 }

--- a/api/internal/gateway/teacher/v1/handler/shift_test.go
+++ b/api/internal/gateway/teacher/v1/handler/shift_test.go
@@ -122,6 +122,208 @@ func TestListShiftSummaries(t *testing.T) {
 	}
 }
 
+func TestListShiftSubmissions(t *testing.T) {
+	t.Parallel()
+	now := jst.Date(2022, 1, 12, 0, 0, 0, 0)
+	subjects := []*classroom.Subject{
+		{
+			Id:         1,
+			Name:       "国語",
+			Color:      "#F8BBD0",
+			SchoolType: classroom.SchoolType_SCHOOL_TYPE_HIGH_SCHOOL,
+			CreatedAt:  now.Unix(),
+			UpdatedAt:  now.Unix(),
+		},
+	}
+	// teachers := []*user.Teacher{
+	// 	{
+	// 		Id:            "teacherid",
+	// 		LastName:      "中村",
+	// 		FirstName:     "広大",
+	// 		LastNameKana:  "なかむら",
+	// 		FirstNameKana: "こうだい",
+	// 		Mail:          "teacher-test001@calmato.jp",
+	// 		Role:          user.Role_ROLE_TEACHER,
+	// 		CreatedAt:     now.Unix(),
+	// 		UpdatedAt:     now.Unix(),
+	// 	},
+	// }
+	teacherSubjects := []*classroom.TeacherSubject{
+		{
+			TeacherId:  "teacherid",
+			SubjectIds: []int64{1},
+		},
+	}
+	teacherShifts := []*lesson.TeacherShift{
+		{
+			TeacherId:      "teacherid",
+			ShiftId:        1,
+			ShiftSummaryId: 1,
+			CreatedAt:      now.Unix(),
+			UpdatedAt:      now.Unix(),
+		},
+		{
+			TeacherId:      "teacherid",
+			ShiftId:        3,
+			ShiftSummaryId: 1,
+			CreatedAt:      now.Unix(),
+			UpdatedAt:      now.Unix(),
+		},
+	}
+	// students := []*user.Student{
+	// 	{
+	// 		Id:            "studentid",
+	// 		LastName:      "中村",
+	// 		FirstName:     "広大",
+	// 		LastNameKana:  "なかむら",
+	// 		FirstNameKana: "こうだい",
+	// 		Mail:          "student-test001@calmato.jp",
+	// 		SchoolType:    user.SchoolType_SCHOOL_TYPE_HIGH_SCHOOL,
+	// 		Grade:         3,
+	// 		CreatedAt:     now.Unix(),
+	// 		UpdatedAt:     now.Unix(),
+	// 	},
+	// }
+	studentSubjects := []*classroom.StudentSubject{
+		{
+			StudentId:  "studentid",
+			SubjectIds: []int64{1},
+		},
+	}
+	studentShifts := []*lesson.StudentShift{
+		{
+			StudentId:      "studentid",
+			ShiftId:        1,
+			ShiftSummaryId: 1,
+			CreatedAt:      now.Unix(),
+			UpdatedAt:      now.Unix(),
+		},
+		{
+			StudentId:      "studentid",
+			ShiftId:        3,
+			ShiftSummaryId: 1,
+			CreatedAt:      now.Unix(),
+			UpdatedAt:      now.Unix(),
+		},
+	}
+	// lessons := []*lesson.Lesson{
+	// 	{
+	// 		Id:             1,
+	// 		ShiftSummaryId: 1,
+	// 		ShiftId:        1,
+	// 		SubjectId:      1,
+	// 		RoomId:         1,
+	// 		TeacherId:      "teacherid",
+	// 		StudentId:      "studentid",
+	// 		Notes:          "感想",
+	// 		CreatedAt:      now.Unix(),
+	// 		UpdatedAt:      now.Unix(),
+	// 	},
+	// }
+	tests := []struct {
+		name      string
+		setup     func(ctx context.Context, t *testing.T, mocks *mocks, ctrl *gomock.Controller)
+		summaryID string
+		shiftID   string
+		expect    *testResponse
+	}{
+		{
+			name: "succcess",
+			setup: func(ctx context.Context, t *testing.T, mocks *mocks, ctrl *gomock.Controller) {
+				submissionsIn := &lesson.ListSubmissionsRequest{ShiftId: 1}
+				submissionsOut := &lesson.ListSubmissionsResponse{
+					TeacherShifts: teacherShifts,
+					StudentShifts: studentShifts,
+				}
+				teacherSubjectsIn := &classroom.MultiGetTeacherSubjectsRequest{TeacherIds: []string{"teacherid"}}
+				teacherSubjectsOut := &classroom.MultiGetTeacherSubjectsResponse{
+					TeacherSubjects: teacherSubjects,
+					Subjects:        subjects,
+				}
+				studentSubjectsIn := &classroom.MultiGetStudentSubjectsRequest{StudentIds: []string{"studentid"}}
+				studentSubjectsOut := &classroom.MultiGetStudentSubjectsResponse{
+					StudentSubjects: studentSubjects,
+					Subjects:        subjects,
+				}
+				mocks.lesson.EXPECT().ListSubmissions(gomock.Any(), submissionsIn).Return(submissionsOut, nil)
+				mocks.classroom.EXPECT().MultiGetTeacherSubjects(gomock.Any(), teacherSubjectsIn).
+					Return(teacherSubjectsOut, nil)
+				mocks.classroom.EXPECT().MultiGetStudentSubjects(gomock.Any(), studentSubjectsIn).
+					Return(studentSubjectsOut, nil)
+			},
+			summaryID: "1",
+			shiftID:   "1",
+			expect: &testResponse{
+				code: http.StatusOK,
+				body: &response.ShiftSubmissionsResponse{
+					Teachers: entity.Teachers{
+						// {
+						// 	ID:            "teacherid",
+						// 	LastName:      "中村",
+						// 	FirstName:     "広大",
+						// 	LastNameKana:  "なかむら",
+						// 	FirstNameKana: "こうだい",
+						// 	Mail:          "teacher-test001@calmato.jp",
+						// 	Role:          entity.RoleTeacher,
+						// 	CreatedAt:     now,
+						// 	UpdatedAt:     now,
+						// 	Subjects: map[entity.SchoolType]entity.Subjects{
+						// 		entity.SchoolTypeElementarySchool: {},
+						// 		entity.SchoolTypeJuniorHighSchool: {},
+						// 		entity.SchoolTypeHighSchool: {
+						// 			{
+						// 				ID:         1,
+						// 				Name:       "国語",
+						// 				Color:      "#F8BBD0",
+						// 				SchoolType: entity.SchoolTypeHighSchool,
+						// 				CreatedAt:  now,
+						// 				UpdatedAt:  now,
+						// 			},
+						// 		},
+						// 	},
+						// },
+					},
+					Students: entity.Students{
+						// {
+						// 	ID:            "studentid",
+						// 	LastName:      "中村",
+						// 	FirstName:     "広大",
+						// 	LastNameKana:  "なかむら",
+						// 	FirstNameKana: "こうだい",
+						// 	Mail:          "student-test001@calmato.jp",
+						// 	SchoolType:    entity.SchoolTypeHighSchool,
+						// 	Grade:         3,
+						// 	CreatedAt:     now,
+						// 	UpdatedAt:     now,
+						// 	Subjects: entity.Subjects{
+						// 		{
+						// 			ID:         1,
+						// 			Name:       "国語",
+						// 			Color:      "#F8BBD0",
+						// 			SchoolType: entity.SchoolTypeHighSchool,
+						// 			CreatedAt:  now,
+						// 			UpdatedAt:  now,
+						// 		},
+						// 	},
+						// },
+					},
+					Lessons: entity.Lessons{},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			path := fmt.Sprintf("/v1/shifts/%s/submissions/%s", tt.summaryID, tt.shiftID)
+			req := newHTTPRequest(t, http.MethodGet, path, nil)
+			testHTTP(t, tt.setup, tt.expect, req)
+		})
+	}
+}
+
 func TestUpdateShiftSummarySchedule(t *testing.T) {
 	t.Parallel()
 

--- a/api/internal/gateway/teacher/v1/handler/student.go
+++ b/api/internal/gateway/teacher/v1/handler/student.go
@@ -1,0 +1,12 @@
+package handler
+
+import (
+	"context"
+
+	gentity "github.com/calmato/shs-web/api/internal/gateway/entity"
+)
+
+func (h *apiV1Handler) multiGetStudents(ctx context.Context, studentIDs []string) (gentity.Students, error) {
+	// TODO: 実装
+	return gentity.Students{}, nil
+}

--- a/api/internal/gateway/teacher/v1/handler/teacher.go
+++ b/api/internal/gateway/teacher/v1/handler/teacher.go
@@ -243,6 +243,11 @@ func (h *apiV1Handler) DeleteTeacher(ctx *gin.Context) {
 	ctx.JSON(http.StatusNoContent, gin.H{})
 }
 
+func (h *apiV1Handler) multiGetTeachers(ctx context.Context, teacherIDs []string) (gentity.Teachers, error) {
+	// TODO: 実装
+	return gentity.Teachers{}, nil
+}
+
 func (h *apiV1Handler) getTeacher(ctx context.Context, teacherID string) (*gentity.Teacher, error) {
 	in := &user.GetTeacherRequest{
 		Id: teacherID,

--- a/api/internal/gateway/teacher/v1/response/shift.go
+++ b/api/internal/gateway/teacher/v1/response/shift.go
@@ -9,6 +9,7 @@ type ShiftSummariesResponse struct {
 type ShiftSubmissionsResponse struct {
 	Teachers entity.Teachers `json:"teachers"` // 出勤可能講師一覧
 	Students entity.Students `json:"students"` // 授業希望生徒一覧
+	Lessons  entity.Lessons  `json:"lessons"`  // 授業一覧
 }
 
 type ShiftsResponse struct {

--- a/api/internal/gateway/teacher/v1/response/shift.go
+++ b/api/internal/gateway/teacher/v1/response/shift.go
@@ -6,6 +6,11 @@ type ShiftSummariesResponse struct {
 	Summaries entity.ShiftSummaries `json:"summaries"` // シフト募集概要一覧
 }
 
+type ShiftSubmissionsResponse struct {
+	Teachers entity.Teachers `json:"teachers"` // 出勤可能講師一覧
+	Students entity.Students `json:"students"` // 授業希望生徒一覧
+}
+
 type ShiftsResponse struct {
 	Summary  *entity.ShiftSummary            `json:"summary"`  // シフト募集概要
 	Shifts   entity.ShiftDetails             `json:"shifts"`   // 募集シフト一覧

--- a/docs/swagger/teacher/components/schemas/v1/shifts.response.yaml
+++ b/docs/swagger/teacher/components/schemas/v1/shifts.response.yaml
@@ -53,6 +53,316 @@ shiftSummariesResponse:
       endAt: '2022-01-14T23:59:59Z'
       createdAt: '2021-12-12T12:12:30.100Z'
       updatedAt: '2021-12-12T12:12:30.100Z'
+shiftSubmissionsResponse:
+  type: object
+  properties:
+    teachers:
+      type: array
+      description: 講師サマリ一覧
+      items:
+        type: object
+        properties:
+          teacher:
+            type: object
+            description: 講師詳細
+            properties:
+              id:
+                type: string
+                description: 講師ID
+              lastName:
+                type: string
+                description: 姓
+              firstName:
+                type: string
+                description: 名
+              lastNameKana:
+                type: string
+                description: 姓(かな)
+              firstNameKana:
+                type: string
+                description: 名(かな)
+              mail:
+                type: string
+                description: メールアドレス
+              role:
+                type: integer
+                format: int32
+                description: 権限 (0:不明, 1:講師, 2:管理者)
+              createdAt:
+                type: string
+                description: 登録日時
+              updatedAt:
+                type: string
+                description: 更新日時
+              subjects:
+                type: object
+                description: 担当教科一覧(Map)
+                properties:
+                  1:
+                    type: array
+                    description: 担当教科一覧(小学校)
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                          format: int64
+                          description: 授業科目ID
+                        name:
+                          type: string
+                          description: 授業科目名
+                        color:
+                          type: string
+                          description: 表示色
+                          format: '#rrggbb'
+                        schoolType:
+                          type: integer
+                          format: int32
+                          description: 校種
+                        createdAt:
+                          type: string
+                          description: 登録日時
+                        updatedAt:
+                          type: string
+                          description: 更新日時
+                  2:
+                    type: array
+                    description: 担当教科一覧(中学校)
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                          format: int64
+                          description: 授業科目ID
+                        name:
+                          type: string
+                          description: 授業科目名
+                        color:
+                          type: string
+                          description: 表示色
+                          format: '#rrggbb'
+                        schoolType:
+                          type: integer
+                          format: int32
+                          description: 校種
+                        createdAt:
+                          type: string
+                          description: 登録日時
+                        updatedAt:
+                          type: string
+                          description: 更新日時
+                  3:
+                    type: array
+                    description: 担当教科一覧(高等学校)
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                          format: int64
+                          description: 授業科目ID
+                        name:
+                          type: string
+                          description: 授業科目名
+                        color:
+                          type: string
+                          description: 表示色
+                          format: '#rrggbb'
+                        schoolType:
+                          type: integer
+                          format: int32
+                          description: 校種
+                        createdAt:
+                          type: string
+                          description: 登録日時
+                        updatedAt:
+                          type: string
+                          description: 更新日時
+    students:
+      type: array
+      description: 生徒サマリ一覧
+      items:
+        type: object
+        properties:
+          student:
+            type: object
+            description: 生徒詳細
+            properties:
+              id:
+                type: string
+                description: 生徒ID
+              lastName:
+                type: string
+                description: 姓
+              firstName:
+                type: string
+                description: 名
+              lastNameKana:
+                type: string
+                description: 姓(かな)
+              firstNameKana:
+                type: string
+                description: 名(かな)
+              mail:
+                type: string
+                description: メールアドレス
+              schoolType:
+                type: integer
+                format: int32
+                description: 校種 (1:小学校, 2:中学校, 3:高等学校)
+              grade:
+                type: integer
+                format: int64
+                description: 学年
+              createdAt:
+                type: string
+                description: 登録日時
+              updatedAt:
+                type: string
+                description: 更新日時
+              subjects:
+                type: array
+                description: 担当教科一覧
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                      format: int64
+                      description: 授業科目ID
+                    name:
+                      type: string
+                      description: 授業科目名
+                    color:
+                      type: string
+                      description: 表示色
+                      format: '#rrggbb'
+                    schoolType:
+                      type: integer
+                      format: int32
+                      description: 校種
+                    createdAt:
+                      type: string
+                      description: 登録日時
+                    updatedAt:
+                      type: string
+                      description: 更新日時
+  example:
+    teachers:
+    - teacher:
+        id: 'kSByoE6FetnPs5Byk3a9Zx'
+        lastName: '中村'
+        firstName: '広大'
+        lastNameKana: 'なかむら'
+        firstNamaKana: 'こうだい'
+        mail: 'teacher-test01@calmato.jp'
+        role: 1
+        createdAt: '2021-12-12T12:12:30.100Z'
+        updatedAt: '2021-12-12T12:12:30.100Z'
+        subjects:
+          1:
+          - id: 1
+            name: 国語
+            color: '#F8BBD0'
+            schoolType: 1
+            createdAt: '2021-12-12T12:12:30Z'
+            updatedAt: '2021-12-12T12:12:30Z'
+          - id: 2
+            name: 数学
+            color: '#BBDEFB'
+            schoolType: 1
+            createdAt: '2021-12-12T12:12:30.100Z'
+            updatedAt: '2021-12-12T12:12:30.100Z'
+          2:
+          - id: 3
+            name: 国語
+            color: '#F8BBD0'
+            schoolType: 2
+            createdAt: '2021-12-12T12:12:30.100Z'
+            updatedAt: '2021-12-12T12:12:30.100Z'
+          - id: 4
+            name: 数学
+            color: '#BBDEFB'
+            schoolType: 2
+            createdAt: '2021-12-12T12:12:30.100Z'
+            updatedAt: '2021-12-12T12:12:30.100Z'
+          3:
+          - id: 5
+            name: 国語
+            color: '#F8BBD0'
+            schoolType: 3
+            createdAt: '2021-12-12T12:12:30.100Z'
+            updatedAt: '2021-12-12T12:12:30.100Z'
+          - id: 6
+            name: 数学
+            color: '#BBDEFB'
+            schoolType: 3
+            createdAt: '2021-12-12T12:12:30.100Z'
+            updatedAt: '2021-12-12T12:12:30.100Z'
+    - teacher:
+        id: 'kSByoE6FetnPs5Byk3a9Zx'
+        lastName: '山田'
+        firstName: 'タダシ'
+        lastNameKana: 'やまだ'
+        firstNamaKana: 'ただし'
+        mail: 'teacher-test02@calmato.jp'
+        role: 2
+        createdAt: '2021-12-12T12:12:30.100Z'
+        updatedAt: '2021-12-12T12:12:30.100Z'
+        subjects:
+          1: {}
+          2: {}
+          3: {}
+    students:
+    - student:
+        id: 'kSByoE6FetnPs5Byk3a9Zx'
+        lastName: '中村'
+        firstName: '広大'
+        lastNameKana: 'なかむら'
+        firstNamaKana: 'こうだい'
+        mail: 'student-test01@calmato.jp'
+        schoolType: 3
+        grade: 2
+        createdAt: '2021-12-12T12:12:30.100Z'
+        updatedAt: '2021-12-12T12:12:30.100Z'
+        subjects:
+        - id: 1
+          name: 国語
+          color: '#F8BBD0'
+          schoolType: 1
+          createdAt: '2021-12-12T12:12:30Z'
+          updatedAt: '2021-12-12T12:12:30Z'
+        - id: 2
+          name: 数学
+          color: '#BBDEFB'
+          schoolType: 1
+          createdAt: '2021-12-12T12:12:30.100Z'
+          updatedAt: '2021-12-12T12:12:30.100Z'
+    - student:
+        id: 'kSByoE6FetnPs5Byk3a9Zx'
+        lastName: '山田'
+        firstName: 'タダシ'
+        lastNameKana: 'やまだ'
+        firstNamaKana: 'ただし'
+        mail: 'teacher-test02@calmato.jp'
+        schoolType: 1
+        grade: 6
+        createdAt: '2021-12-12T12:12:30.100Z'
+        updatedAt: '2021-12-12T12:12:30.100Z'
+        subjects:
+        - id: 1
+          name: 国語
+          color: '#F8BBD0'
+          schoolType: 1
+          createdAt: '2021-12-12T12:12:30Z'
+          updatedAt: '2021-12-12T12:12:30Z'
+        - id: 2
+          name: 数学
+          color: '#BBDEFB'
+          schoolType: 1
+          createdAt: '2021-12-12T12:12:30.100Z'
+          updatedAt: '2021-12-12T12:12:30.100Z'
 shiftsResponse:
   type: object
   properties:

--- a/docs/swagger/teacher/components/schemas/v1/shifts.response.yaml
+++ b/docs/swagger/teacher/components/schemas/v1/shifts.response.yaml
@@ -58,172 +58,45 @@ shiftSubmissionsResponse:
   properties:
     teachers:
       type: array
-      description: 講師サマリ一覧
+      description: 出勤可能講師一覧
       items:
         type: object
         properties:
-          teacher:
+          id:
+            type: string
+            description: 講師ID
+          lastName:
+            type: string
+            description: 姓
+          firstName:
+            type: string
+            description: 名
+          lastNameKana:
+            type: string
+            description: 姓(かな)
+          firstNameKana:
+            type: string
+            description: 名(かな)
+          mail:
+            type: string
+            description: メールアドレス
+          role:
+            type: integer
+            format: int32
+            description: 権限 (0:不明, 1:講師, 2:管理者)
+          createdAt:
+            type: string
+            description: 登録日時
+          updatedAt:
+            type: string
+            description: 更新日時
+          subjects:
             type: object
-            description: 講師詳細
+            description: 担当教科一覧(Map)
             properties:
-              id:
-                type: string
-                description: 講師ID
-              lastName:
-                type: string
-                description: 姓
-              firstName:
-                type: string
-                description: 名
-              lastNameKana:
-                type: string
-                description: 姓(かな)
-              firstNameKana:
-                type: string
-                description: 名(かな)
-              mail:
-                type: string
-                description: メールアドレス
-              role:
-                type: integer
-                format: int32
-                description: 権限 (0:不明, 1:講師, 2:管理者)
-              createdAt:
-                type: string
-                description: 登録日時
-              updatedAt:
-                type: string
-                description: 更新日時
-              subjects:
-                type: object
-                description: 担当教科一覧(Map)
-                properties:
-                  1:
-                    type: array
-                    description: 担当教科一覧(小学校)
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: integer
-                          format: int64
-                          description: 授業科目ID
-                        name:
-                          type: string
-                          description: 授業科目名
-                        color:
-                          type: string
-                          description: 表示色
-                          format: '#rrggbb'
-                        schoolType:
-                          type: integer
-                          format: int32
-                          description: 校種
-                        createdAt:
-                          type: string
-                          description: 登録日時
-                        updatedAt:
-                          type: string
-                          description: 更新日時
-                  2:
-                    type: array
-                    description: 担当教科一覧(中学校)
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: integer
-                          format: int64
-                          description: 授業科目ID
-                        name:
-                          type: string
-                          description: 授業科目名
-                        color:
-                          type: string
-                          description: 表示色
-                          format: '#rrggbb'
-                        schoolType:
-                          type: integer
-                          format: int32
-                          description: 校種
-                        createdAt:
-                          type: string
-                          description: 登録日時
-                        updatedAt:
-                          type: string
-                          description: 更新日時
-                  3:
-                    type: array
-                    description: 担当教科一覧(高等学校)
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: integer
-                          format: int64
-                          description: 授業科目ID
-                        name:
-                          type: string
-                          description: 授業科目名
-                        color:
-                          type: string
-                          description: 表示色
-                          format: '#rrggbb'
-                        schoolType:
-                          type: integer
-                          format: int32
-                          description: 校種
-                        createdAt:
-                          type: string
-                          description: 登録日時
-                        updatedAt:
-                          type: string
-                          description: 更新日時
-    students:
-      type: array
-      description: 生徒サマリ一覧
-      items:
-        type: object
-        properties:
-          student:
-            type: object
-            description: 生徒詳細
-            properties:
-              id:
-                type: string
-                description: 生徒ID
-              lastName:
-                type: string
-                description: 姓
-              firstName:
-                type: string
-                description: 名
-              lastNameKana:
-                type: string
-                description: 姓(かな)
-              firstNameKana:
-                type: string
-                description: 名(かな)
-              mail:
-                type: string
-                description: メールアドレス
-              schoolType:
-                type: integer
-                format: int32
-                description: 校種 (1:小学校, 2:中学校, 3:高等学校)
-              grade:
-                type: integer
-                format: int64
-                description: 学年
-              createdAt:
-                type: string
-                description: 登録日時
-              updatedAt:
-                type: string
-                description: 更新日時
-              subjects:
+              1:
                 type: array
-                description: 担当教科一覧
+                description: 担当教科一覧(小学校)
                 items:
                   type: object
                   properties:
@@ -248,121 +121,303 @@ shiftSubmissionsResponse:
                     updatedAt:
                       type: string
                       description: 更新日時
+              2:
+                type: array
+                description: 担当教科一覧(中学校)
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                      format: int64
+                      description: 授業科目ID
+                    name:
+                      type: string
+                      description: 授業科目名
+                    color:
+                      type: string
+                      description: 表示色
+                      format: '#rrggbb'
+                    schoolType:
+                      type: integer
+                      format: int32
+                      description: 校種
+                    createdAt:
+                      type: string
+                      description: 登録日時
+                    updatedAt:
+                      type: string
+                      description: 更新日時
+              3:
+                type: array
+                description: 担当教科一覧(高等学校)
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                      format: int64
+                      description: 授業科目ID
+                    name:
+                      type: string
+                      description: 授業科目名
+                    color:
+                      type: string
+                      description: 表示色
+                      format: '#rrggbb'
+                    schoolType:
+                      type: integer
+                      format: int32
+                      description: 校種
+                    createdAt:
+                      type: string
+                      description: 登録日時
+                    updatedAt:
+                      type: string
+                      description: 更新日時
+    students:
+      type: array
+      description: 授業希望生徒一覧
+      items:
+        type: object
+        properties:
+          id:
+            type: string
+            description: 生徒ID
+          lastName:
+            type: string
+            description: 姓
+          firstName:
+            type: string
+            description: 名
+          lastNameKana:
+            type: string
+            description: 姓(かな)
+          firstNameKana:
+            type: string
+            description: 名(かな)
+          mail:
+            type: string
+            description: メールアドレス
+          schoolType:
+            type: integer
+            format: int32
+            description: 校種 (1:小学校, 2:中学校, 3:高等学校)
+          grade:
+            type: integer
+            format: int64
+            description: 学年
+          createdAt:
+            type: string
+            description: 登録日時
+          updatedAt:
+            type: string
+            description: 更新日時
+          subjects:
+            type: array
+            description: 担当教科一覧
+            items:
+              type: object
+              properties:
+                id:
+                  type: integer
+                  format: int64
+                  description: 授業科目ID
+                name:
+                  type: string
+                  description: 授業科目名
+                color:
+                  type: string
+                  description: 表示色
+                  format: '#rrggbb'
+                schoolType:
+                  type: integer
+                  format: int32
+                  description: 校種
+                createdAt:
+                  type: string
+                  description: 登録日時
+                updatedAt:
+                  type: string
+                  description: 更新日時
+    lessons:
+      type: array
+      description: 授業一覧
+      items:
+        type: object
+        properties:
+          id:
+            type: integer
+            format: int64
+            description: 授業ID
+          shiftId:
+            type: integer
+            format: int64
+            description: 授業スケジュールID
+          subjectId:
+            type: integer
+            format: int64
+            description: 授業科目ID
+          room:
+            type: integer
+            format: int32
+            description: 教室番号
+          teacherId:
+            type: string
+            description: 講師ID
+          studentId:
+            type: string
+            description: 生徒ID
+          startAt:
+            type: string
+            description: 授業開始日時
+          endAt:
+            type: string
+            format: 'HHMM'
+            description: 授業終了日時
+          notes:
+            type: string
+            description: 備考
+          createdAt:
+            type: string
+            description: 登録日時
+          updatedAt:
+            type: string
+            description: 更新日時
   example:
     teachers:
-    - teacher:
-        id: 'kSByoE6FetnPs5Byk3a9Zx'
-        lastName: '中村'
-        firstName: '広大'
-        lastNameKana: 'なかむら'
-        firstNamaKana: 'こうだい'
-        mail: 'teacher-test01@calmato.jp'
-        role: 1
-        createdAt: '2021-12-12T12:12:30.100Z'
-        updatedAt: '2021-12-12T12:12:30.100Z'
-        subjects:
-          1:
-          - id: 1
-            name: 国語
-            color: '#F8BBD0'
-            schoolType: 1
-            createdAt: '2021-12-12T12:12:30Z'
-            updatedAt: '2021-12-12T12:12:30Z'
-          - id: 2
-            name: 数学
-            color: '#BBDEFB'
-            schoolType: 1
-            createdAt: '2021-12-12T12:12:30.100Z'
-            updatedAt: '2021-12-12T12:12:30.100Z'
-          2:
-          - id: 3
-            name: 国語
-            color: '#F8BBD0'
-            schoolType: 2
-            createdAt: '2021-12-12T12:12:30.100Z'
-            updatedAt: '2021-12-12T12:12:30.100Z'
-          - id: 4
-            name: 数学
-            color: '#BBDEFB'
-            schoolType: 2
-            createdAt: '2021-12-12T12:12:30.100Z'
-            updatedAt: '2021-12-12T12:12:30.100Z'
-          3:
-          - id: 5
-            name: 国語
-            color: '#F8BBD0'
-            schoolType: 3
-            createdAt: '2021-12-12T12:12:30.100Z'
-            updatedAt: '2021-12-12T12:12:30.100Z'
-          - id: 6
-            name: 数学
-            color: '#BBDEFB'
-            schoolType: 3
-            createdAt: '2021-12-12T12:12:30.100Z'
-            updatedAt: '2021-12-12T12:12:30.100Z'
-    - teacher:
-        id: 'kSByoE6FetnPs5Byk3a9Zx'
-        lastName: '山田'
-        firstName: 'タダシ'
-        lastNameKana: 'やまだ'
-        firstNamaKana: 'ただし'
-        mail: 'teacher-test02@calmato.jp'
-        role: 2
-        createdAt: '2021-12-12T12:12:30.100Z'
-        updatedAt: '2021-12-12T12:12:30.100Z'
-        subjects:
-          1: {}
-          2: {}
-          3: {}
+    - id: 'kSByoE6FetnPs5Byk3a9Zx'
+      lastName: '中村'
+      firstName: '広大'
+      lastNameKana: 'なかむら'
+      firstNamaKana: 'こうだい'
+      mail: 'teacher-test01@calmato.jp'
+      role: 1
+      createdAt: '2021-12-12T12:12:30.100Z'
+      updatedAt: '2021-12-12T12:12:30.100Z'
+      subjects:
+        1:
+        - id: 1
+          name: 国語
+          color: '#F8BBD0'
+          schoolType: 1
+          createdAt: '2021-12-12T12:12:30Z'
+          updatedAt: '2021-12-12T12:12:30Z'
+        - id: 2
+          name: 数学
+          color: '#BBDEFB'
+          schoolType: 1
+          createdAt: '2021-12-12T12:12:30.100Z'
+          updatedAt: '2021-12-12T12:12:30.100Z'
+        2:
+        - id: 3
+          name: 国語
+          color: '#F8BBD0'
+          schoolType: 2
+          createdAt: '2021-12-12T12:12:30.100Z'
+          updatedAt: '2021-12-12T12:12:30.100Z'
+        - id: 4
+          name: 数学
+          color: '#BBDEFB'
+          schoolType: 2
+          createdAt: '2021-12-12T12:12:30.100Z'
+          updatedAt: '2021-12-12T12:12:30.100Z'
+        3:
+        - id: 5
+          name: 国語
+          color: '#F8BBD0'
+          schoolType: 3
+          createdAt: '2021-12-12T12:12:30.100Z'
+          updatedAt: '2021-12-12T12:12:30.100Z'
+        - id: 6
+          name: 数学
+          color: '#BBDEFB'
+          schoolType: 3
+          createdAt: '2021-12-12T12:12:30.100Z'
+          updatedAt: '2021-12-12T12:12:30.100Z'
+    - id: 'kSByoE6FetnPs5Byk3a9Zx'
+      lastName: '山田'
+      firstName: 'タダシ'
+      lastNameKana: 'やまだ'
+      firstNamaKana: 'ただし'
+      mail: 'teacher-test02@calmato.jp'
+      role: 2
+      createdAt: '2021-12-12T12:12:30.100Z'
+      updatedAt: '2021-12-12T12:12:30.100Z'
+      subjects:
+        1: {}
+        2: {}
+        3: {}
     students:
-    - student:
-        id: 'kSByoE6FetnPs5Byk3a9Zx'
-        lastName: '中村'
-        firstName: '広大'
-        lastNameKana: 'なかむら'
-        firstNamaKana: 'こうだい'
-        mail: 'student-test01@calmato.jp'
-        schoolType: 3
-        grade: 2
-        createdAt: '2021-12-12T12:12:30.100Z'
-        updatedAt: '2021-12-12T12:12:30.100Z'
-        subjects:
-        - id: 1
-          name: 国語
-          color: '#F8BBD0'
-          schoolType: 1
-          createdAt: '2021-12-12T12:12:30Z'
-          updatedAt: '2021-12-12T12:12:30Z'
-        - id: 2
-          name: 数学
-          color: '#BBDEFB'
-          schoolType: 1
-          createdAt: '2021-12-12T12:12:30.100Z'
-          updatedAt: '2021-12-12T12:12:30.100Z'
-    - student:
-        id: 'kSByoE6FetnPs5Byk3a9Zx'
-        lastName: '山田'
-        firstName: 'タダシ'
-        lastNameKana: 'やまだ'
-        firstNamaKana: 'ただし'
-        mail: 'teacher-test02@calmato.jp'
+    - id: 'kSByoE6FetnPs5Byk3a9Zx'
+      lastName: '中村'
+      firstName: '広大'
+      lastNameKana: 'なかむら'
+      firstNamaKana: 'こうだい'
+      mail: 'student-test01@calmato.jp'
+      schoolType: 3
+      grade: 2
+      createdAt: '2021-12-12T12:12:30.100Z'
+      updatedAt: '2021-12-12T12:12:30.100Z'
+      subjects:
+      - id: 1
+        name: 国語
+        color: '#F8BBD0'
         schoolType: 1
-        grade: 6
+        createdAt: '2021-12-12T12:12:30Z'
+        updatedAt: '2021-12-12T12:12:30Z'
+      - id: 2
+        name: 数学
+        color: '#BBDEFB'
+        schoolType: 1
         createdAt: '2021-12-12T12:12:30.100Z'
         updatedAt: '2021-12-12T12:12:30.100Z'
-        subjects:
-        - id: 1
-          name: 国語
-          color: '#F8BBD0'
-          schoolType: 1
-          createdAt: '2021-12-12T12:12:30Z'
-          updatedAt: '2021-12-12T12:12:30Z'
-        - id: 2
-          name: 数学
-          color: '#BBDEFB'
-          schoolType: 1
-          createdAt: '2021-12-12T12:12:30.100Z'
-          updatedAt: '2021-12-12T12:12:30.100Z'
+    - id: 'kSByoE6FetnPs5Byk3a9Zx'
+      lastName: '山田'
+      firstName: 'タダシ'
+      lastNameKana: 'やまだ'
+      firstNamaKana: 'ただし'
+      mail: 'teacher-test02@calmato.jp'
+      schoolType: 1
+      grade: 6
+      createdAt: '2021-12-12T12:12:30.100Z'
+      updatedAt: '2021-12-12T12:12:30.100Z'
+      subjects:
+      - id: 1
+        name: 国語
+        color: '#F8BBD0'
+        schoolType: 1
+        createdAt: '2021-12-12T12:12:30Z'
+        updatedAt: '2021-12-12T12:12:30Z'
+      - id: 2
+        name: 数学
+        color: '#BBDEFB'
+        schoolType: 1
+        createdAt: '2021-12-12T12:12:30.100Z'
+        updatedAt: '2021-12-12T12:12:30.100Z'
+    lessons:
+    - id: 1
+      shiftId: 1
+      subjectId: 1
+      room: 1
+      teacherId: 'kSByoE6FetnPs5Byk3a9Zx'
+      studentId: 'kSByoE6FetnPs5Byk3a9Zx'
+      startAt: '2022-02-02T17:00:00.100Z'
+      endAt: '2022-02-02T18:30:00.100Z'
+      notes: '授業メモです。'
+      createdAt: '2021-12-12T12:12:30.100Z'
+      updatedAt: '2021-12-12T12:12:30.100Z'
+    - id: 2
+      shiftId: 1
+      subjectId: 1
+      room: 2
+      teacherId: 'kSByoE6FetnPs5Byk3a9Zx'
+      studentId: 'kSByoE6FetnPs5Byk3a9Zx'
+      startAt: '2022-02-02T17:00:00.100Z'
+      endAt: '2022-02-02T18:30:00.100Z'
+      notes: '授業メモです。'
+      createdAt: '2021-12-12T12:12:30.100Z'
+      udpatedAt: '2021-12-12T12:12:30.100Z'
 shiftsResponse:
   type: object
   properties:

--- a/docs/swagger/teacher/openapi.yaml
+++ b/docs/swagger/teacher/openapi.yaml
@@ -64,6 +64,8 @@ paths:
     $ref: './paths/v1/shifts/_shiftId/schedule.yaml'
   /v1/shifts/{shiftId}/lessons:
     $ref: './paths/v1/shifts/_shiftId/lessons/index.yaml'
+  /v1/shifts/{shiftId}/submissions/{submissionId}:
+    $ref: './paths/v1/shifts/_shiftId/submissions/_submissionId.yaml'
   /v1/shifts/{shiftId}/teachers/{teacherId}:
     $ref: './paths/v1/shifts/_shiftId/teachers/_teacherId.yaml'
   /v1/shifts/{shiftId}/students/{studentId}:
@@ -133,6 +135,8 @@ components:
       $ref: './components/schemas/v1/schedules.response.yaml#/schedulesResponse'
     v1ShiftSummariesResponse:
       $ref: './components/schemas/v1/shifts.response.yaml#/shiftSummariesResponse'
+    v1ShiftSubmissionsResponse:
+      $ref: './components/schemas/v1/shifts.response.yaml#/shiftSubmissionsResponse'
     v1ShiftsResponse:
       $ref: './components/schemas/v1/shifts.response.yaml#/shiftsResponse'
     v1TeacherSubmissionsResponse:

--- a/docs/swagger/teacher/paths/v1/shifts/_shiftId/submissions/_submissionId.yaml
+++ b/docs/swagger/teacher/paths/v1/shifts/_shiftId/submissions/_submissionId.yaml
@@ -1,0 +1,36 @@
+get:
+  summary: 時間毎のシフト提出状況一覧
+  tags:
+  - Shift
+  security:
+  - BearerAuth: []
+  parameters:
+  - in: path
+    name: shiftId
+    required: true
+    schema:
+      type: integer
+      format: int64
+    description: シフトサマリID
+    example: 1
+  - in: path
+    name: submissionId
+    required: true
+    schema:
+      type: integer
+      format: int64
+    description: シフト詳細ID
+    example: 1
+  responses:
+    200:
+      description: A successful response.
+      content:
+        application/json:
+          schema:
+            $ref: './../../../../../openapi.yaml#/components/schemas/v1ShiftSubmissionsResponse'
+    default:
+      description: An unexpected error response.
+      content:
+        application/json:
+          schema:
+            $ref: './../../../../../openapi.yaml#/components/schemas/errorResponse'


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
シフトIDに対する勤務可能講師, 授業希望生徒の一覧をそれぞれ取得するAPIを実装しました

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->
* [ ] User APIの追加実装分
* [ ] テスト作成

## 備考

<!-- マージ後に必要な操作などがあればここに -->
