### PR TITLE
feat(gateway): add response field to get student shift api

### DIFF
--- a/api/internal/gateway/teacher/v1/entity/student_submission.go
+++ b/api/internal/gateway/teacher/v1/entity/student_submission.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/calmato/shs-web/api/internal/gateway/entity"
 	"github.com/calmato/shs-web/api/pkg/jst"
+	"github.com/calmato/shs-web/api/proto/lesson"
 )
 
 type StudentSubmission struct {
@@ -20,6 +21,13 @@ type StudentSubmission struct {
 }
 
 type StudentSubmissions []*StudentSubmission
+
+type StudentSuggestedLesson struct {
+	SubjectID int64 `json:"subjectId"` // 授業ID
+	Total     int64 `json:"total"`     // 希望授業数
+}
+
+type StudentSuggestedLessons []*StudentSuggestedLesson
 
 type StudentSubmissionDetail struct {
 	Student               *Student `json:"student"`               // 生徒情報
@@ -60,6 +68,21 @@ func NewStudentSubmissions(
 		ss[i] = NewStudentSubmission(s, submission)
 	}
 	return ss
+}
+
+func NewStudentSuggestedLesson(suggestedLesson *lesson.SuggestedLesson) *StudentSuggestedLesson {
+	return &StudentSuggestedLesson{
+		SubjectID: suggestedLesson.SubjectId,
+		Total:     suggestedLesson.Total,
+	}
+}
+
+func NewStudentSuggestedLessons(submission *entity.StudentSubmission) StudentSuggestedLessons {
+	ls := make(StudentSuggestedLessons, len(submission.SuggestedLessons))
+	for i := range submission.SuggestedLessons {
+		ls[i] = NewStudentSuggestedLesson(submission.SuggestedLessons[i])
+	}
+	return ls
 }
 
 func NewStudentSubmissionDetail(

--- a/api/internal/gateway/teacher/v1/entity/student_submission_test.go
+++ b/api/internal/gateway/teacher/v1/entity/student_submission_test.go
@@ -161,7 +161,7 @@ func TestStudentSuggestedLesson(t *testing.T) {
 				Total:     4,
 			},
 			expect: &StudentSuggestedLesson{
-				SubjectID: 4,
+				SubjectID: 1,
 				Total:     4,
 			},
 		},

--- a/api/internal/gateway/teacher/v1/entity/student_submission_test.go
+++ b/api/internal/gateway/teacher/v1/entity/student_submission_test.go
@@ -147,6 +147,74 @@ func TestStudentSubmissions(t *testing.T) {
 	}
 }
 
+func TestStudentSuggestedLesson(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		lesson *lesson.SuggestedLesson
+		expect *StudentSuggestedLesson
+	}{
+		{
+			name: "success",
+			lesson: &lesson.SuggestedLesson{
+				SubjectId: 1,
+				Total:     4,
+			},
+			expect: &StudentSuggestedLesson{
+				SubjectID: 4,
+				Total:     4,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, NewStudentSuggestedLesson(tt.lesson))
+		})
+	}
+}
+
+func TestStudentSuggestedLessons(t *testing.T) {
+	t.Parallel()
+	now := jst.Date(2021, 8, 2, 18, 30, 0, 0)
+	tests := []struct {
+		name       string
+		submission *entity.StudentSubmission
+		expect     StudentSuggestedLessons
+	}{
+		{
+			name: "success",
+			submission: &entity.StudentSubmission{
+				StudentSubmission: &lesson.StudentSubmission{
+					StudentId:      "kSByoE6FetnPs5Byk3a9Zx",
+					ShiftSummaryId: 1,
+					Decided:        true,
+					SuggestedLessons: []*lesson.SuggestedLesson{
+						{SubjectId: 1, Total: 4},
+						{SubjectId: 2, Total: 4},
+					},
+					CreatedAt: now.Unix(),
+					UpdatedAt: now.Unix(),
+				},
+			},
+			expect: StudentSuggestedLessons{
+				{SubjectID: 1, Total: 4},
+				{SubjectID: 2, Total: 4},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, NewStudentSuggestedLessons(tt.submission))
+		})
+	}
+}
+
 func TestStudentSubmissionDetail(t *testing.T) {
 	t.Parallel()
 	now := jst.Date(2021, 8, 2, 18, 30, 0, 0)

--- a/api/internal/gateway/teacher/v1/handler/student_shift.go
+++ b/api/internal/gateway/teacher/v1/handler/student_shift.go
@@ -62,8 +62,9 @@ func (h *apiV1Handler) ListEnabledStudentShifts(ctx *gin.Context) {
 	}
 
 	res := &response.StudentShiftsResponse{
-		Summary: entity.NewStudentSubmission(gsummary, submission),
-		Shifts:  entity.NewEnabledStudentShiftDetails(summary, shifts, studentShifts.MapByShiftID()),
+		Summary:          entity.NewStudentSubmission(gsummary, submission),
+		Shifts:           entity.NewEnabledStudentShiftDetails(summary, shifts, studentShifts.MapByShiftID()),
+		SuggestedLessons: entity.NewStudentSuggestedLessons(submission),
 	}
 	ctx.JSON(http.StatusOK, res)
 }

--- a/api/internal/gateway/teacher/v1/handler/student_shift_test.go
+++ b/api/internal/gateway/teacher/v1/handler/student_shift_test.go
@@ -58,8 +58,11 @@ func TestListEnabledStudentShifts(t *testing.T) {
 		StudentId:      idmock,
 		ShiftSummaryId: 1,
 		Decided:        true,
-		CreatedAt:      now.Unix(),
-		UpdatedAt:      now.Unix(),
+		SuggestedLessons: []*lesson.SuggestedLesson{
+			{SubjectId: 1, Total: 4},
+		},
+		CreatedAt: now.Unix(),
+		UpdatedAt: now.Unix(),
 	}
 	studentShifts := []*lesson.StudentShift{
 		{
@@ -135,6 +138,9 @@ func TestListEnabledStudentShifts(t *testing.T) {
 								{ID: 3, Enabled: true, StartTime: "1700", EndTime: "1830"},
 							},
 						},
+					},
+					SuggestedLessons: entity.StudentSuggestedLessons{
+						{SubjectID: 1, Total: 4},
 					},
 				},
 			},

--- a/api/internal/gateway/teacher/v1/response/submission.go
+++ b/api/internal/gateway/teacher/v1/response/submission.go
@@ -12,6 +12,7 @@ type TeacherShiftsResponse struct {
 }
 
 type StudentShiftsResponse struct {
-	Summary *entity.StudentSubmission  `json:"summary"` // 授業希望募集概要
-	Shifts  entity.StudentShiftDetails `json:"shifts"`  // 募集授業一覧
+	Summary          *entity.StudentSubmission      `json:"summary"`          // 授業希望募集概要
+	Shifts           entity.StudentShiftDetails     `json:"shifts"`           // 募集授業一覧
+	SuggestedLessons entity.StudentSuggestedLessons `json:"suggestedLessons"` // 授業毎の受講希望回数
 }

--- a/docs/swagger/teacher/components/schemas/v1/shifts.response.yaml
+++ b/docs/swagger/teacher/components/schemas/v1/shifts.response.yaml
@@ -1147,6 +1147,20 @@ studentShiftsResponse:
                   type: string
                   format: 'HHMM'
                   description: 授業終了時間
+    suggestedLessons:
+      type: array
+      description: 科目毎の授業希望情報
+      items:
+        type: object
+        properties:
+          subjectId:
+            type: integer
+            format: int64
+            description: 授業科目ID
+          total:
+            type: integer
+            format: int64
+            description: 授業希望回数
   example:
     summary:
       year: 2022
@@ -1183,3 +1197,6 @@ studentShiftsResponse:
         enabled: true
         startTime: '1830'
         endTime: '2000'
+    suggestedLessons:
+    - subjectId: 1
+      total: 4


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
生徒の受講希望一覧取得APIで科目毎の受講希望回数も返すようにしました。

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
