### PR TITLE
fix(classroom-api): fix create subject response

### DIFF
--- a/api/internal/classroom/api/subject.go
+++ b/api/internal/classroom/api/subject.go
@@ -123,7 +123,9 @@ func (s *classroomService) CreateSubject(
 		return nil, gRPCError(err)
 	}
 
-	res := &classroom.CreateSubjectResponse{}
+	res := &classroom.CreateSubjectResponse{
+		Subject: subject.Proto(),
+	}
 	return res, nil
 }
 

--- a/api/internal/classroom/api/subject_test.go
+++ b/api/internal/classroom/api/subject_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/calmato/shs-web/api/internal/classroom/database"
 	"github.com/calmato/shs-web/api/internal/classroom/entity"
@@ -345,7 +346,15 @@ func TestCreateSubject(t *testing.T) {
 			req: req,
 			expect: &testResponse{
 				code: codes.OK,
-				body: &classroom.CreateSubjectResponse{},
+				body: &classroom.CreateSubjectResponse{
+					Subject: &classroom.Subject{
+						Name:       "国語",
+						Color:      "#F8BBD0",
+						SchoolType: classroom.SchoolType_SCHOOL_TYPE_HIGH_SCHOOL,
+						CreatedAt:  time.Time{}.Unix(),
+						UpdatedAt:  time.Time{}.Unix(),
+					},
+				},
 			},
 		},
 		{


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
授業科目登録APIにて、レスポンスの詰め忘れがあってnilポインターが起こっていた箇所を修正しました

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
