### PR TITLE
feat(web/teacher): add loader in shift detail page

### DIFF
--- a/web/teacher/src/pages/shifts/_id.vue
+++ b/web/teacher/src/pages/shifts/_id.vue
@@ -1,5 +1,9 @@
 <template>
   <div>
+    <!-- 初回ロード (初回の画面描画に時間がかかるため) -->
+    <v-overlay :value="overlay">
+      <v-progress-circular indeterminate size="64" />
+    </v-overlay>
     <!-- PCレイアウト -->
     <pc-shift-detail
       class="hidden-sm-and-down"
@@ -79,6 +83,8 @@ export default defineComponent({
     const store = useStore()
 
     const summaryId = Number(route.value.params.id)
+
+    const overlay = ref<boolean>(true)
     const dialogKey = ref<ShiftDialogKey>('未選択')
     const lessonLoading = ref<boolean>(false)
     const form = reactive<ShiftLessonForm>({ params: { ...ShiftLessonParams } })
@@ -102,6 +108,7 @@ export default defineComponent({
 
     useAsync(async () => {
       await listShiftDetails()
+      overlay.value = false
     })
 
     async function listShiftDetails(): Promise<void> {
@@ -310,6 +317,7 @@ export default defineComponent({
     }
 
     return {
+      overlay,
       loading,
       lessonLoading,
       dialog,


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
授業登録画面の初期描画が遅いので、まずは仮のローディング画面出すようにしました
このあとスケルトンローダーに置き換えられたらしたいとおもいます

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
