### PR TITLE
feat(lesson-api): add field to shift summary entity

### DIFF
--- a/api/internal/lesson/database/database.go
+++ b/api/internal/lesson/database/database.go
@@ -62,6 +62,7 @@ type Lesson interface {
 
 type ShiftSummary interface {
 	List(ctx context.Context, p *ListShiftSummariesParams, fields ...string) (entity.ShiftSummaries, error)
+	MultiGet(ctx context.Context, ids []int64, fields ...string) (entity.ShiftSummaries, error)
 	Get(ctx context.Context, id int64, fields ...string) (*entity.ShiftSummary, error)
 	UpdateSchedule(ctx context.Context, id int64, openAt, endAt time.Time) error
 	Delete(ctx context.Context, id int64) error

--- a/api/internal/lesson/database/shift_summary.go
+++ b/api/internal/lesson/database/shift_summary.go
@@ -12,7 +12,7 @@ import (
 const shiftSummaryTable = "shift_summaries"
 
 var shiftSummaryFields = []string{
-	"id", "year_month", "open_at", "end_at", "created_at", "updated_at",
+	"id", "year_month", "decided", "open_at", "end_at", "created_at", "updated_at",
 }
 
 type shiftSummary struct {
@@ -66,6 +66,23 @@ func (s *shiftSummary) List(
 		return nil, dbError(err)
 	}
 	summaries.Fill(now)
+	return summaries, nil
+}
+
+func (s *shiftSummary) MultiGet(ctx context.Context, ids []int64, fields ...string) (entity.ShiftSummaries, error) {
+	var summaries entity.ShiftSummaries
+	if len(fields) == 0 {
+		fields = shiftSummaryFields
+	}
+
+	stmt := s.db.DB.Table(shiftSummaryTable).Select(fields).
+		Where("id IN (?)", ids)
+
+	err := stmt.Find(&summaries).Error
+	if err != nil {
+		return nil, dbError(err)
+	}
+	summaries.Fill(s.now())
 	return summaries, nil
 }
 

--- a/api/internal/lesson/entity/lesson.go
+++ b/api/internal/lesson/entity/lesson.go
@@ -1,6 +1,7 @@
 package entity
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/calmato/shs-web/api/pkg/set"
@@ -37,12 +38,34 @@ func (l *Lesson) Proto() *lesson.Lesson {
 	}
 }
 
+func (ls Lessons) ShiftSummaryIDs() []int64 {
+	set := set.New(len(ls))
+	for i := range ls {
+		set.Add(ls[i].ShiftSummaryID)
+	}
+	return set.Int64s()
+}
+
 func (ls Lessons) ShiftIDs() []int64 {
 	set := set.New(len(ls))
 	for i := range ls {
 		set.Add(ls[i].ShiftID)
 	}
 	return set.Int64s()
+}
+
+func (ls Lessons) Decided(summaries map[int64]*ShiftSummary) (Lessons, error) {
+	res := make(Lessons, 0, len(ls))
+	for i := range ls {
+		summary, ok := summaries[ls[i].ShiftSummaryID]
+		if !ok {
+			return nil, fmt.Errorf("shift summary is not found")
+		}
+		if summary.Decided {
+			res = append(res, ls[i])
+		}
+	}
+	return res, nil
 }
 
 func (ls Lessons) Proto() []*lesson.Lesson {

--- a/api/internal/lesson/entity/lesson_test.go
+++ b/api/internal/lesson/entity/lesson_test.go
@@ -54,6 +54,138 @@ func TestLesson_Proto(t *testing.T) {
 	}
 }
 
+func TestLessons_ShiftSummaryIDs(t *testing.T) {
+	t.Parallel()
+	now := jst.Now()
+	tests := []struct {
+		name    string
+		lessons Lessons
+		expect  []int64
+	}{
+		{
+			name: "success",
+			lessons: Lessons{
+				{
+					ID:             1,
+					ShiftSummaryID: 1,
+					ShiftID:        1,
+					SubjectID:      1,
+					RoomID:         1,
+					TeacherID:      "teacherid",
+					StudentID:      "studentid",
+					Notes:          "",
+					CreatedAt:      now,
+					UpdatedAt:      now,
+				},
+			},
+			expect: []int64{1},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.lessons.ShiftSummaryIDs())
+		})
+	}
+}
+
+func TestLessons_ShiftIDs(t *testing.T) {
+	t.Parallel()
+	now := jst.Now()
+	tests := []struct {
+		name    string
+		lessons Lessons
+		expect  []int64
+	}{
+		{
+			name: "success",
+			lessons: Lessons{
+				{
+					ID:             1,
+					ShiftSummaryID: 1,
+					ShiftID:        1,
+					SubjectID:      1,
+					RoomID:         1,
+					TeacherID:      "teacherid",
+					StudentID:      "studentid",
+					Notes:          "",
+					CreatedAt:      now,
+					UpdatedAt:      now,
+				},
+			},
+			expect: []int64{1},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.lessons.ShiftIDs())
+		})
+	}
+}
+
+func TestLessons_Decided(t *testing.T) {
+	t.Parallel()
+	now := jst.Now()
+	tests := []struct {
+		name      string
+		lessons   Lessons
+		summaries map[int64]*ShiftSummary
+		expect    Lessons
+		isErr     bool
+	}{
+		{
+			name: "success",
+			lessons: Lessons{
+				{
+					ID:             1,
+					ShiftSummaryID: 1,
+					ShiftID:        1,
+					SubjectID:      1,
+					RoomID:         1,
+					TeacherID:      "teacherid",
+					StudentID:      "studentid",
+					Notes:          "",
+					CreatedAt:      now,
+					UpdatedAt:      now,
+				},
+			},
+			summaries: map[int64]*ShiftSummary{
+				1: {Decided: true},
+			},
+			expect: Lessons{
+				{
+					ID:             1,
+					ShiftSummaryID: 1,
+					ShiftID:        1,
+					SubjectID:      1,
+					RoomID:         1,
+					TeacherID:      "teacherid",
+					StudentID:      "studentid",
+					Notes:          "",
+					CreatedAt:      now,
+					UpdatedAt:      now,
+				},
+			},
+			isErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual, err := tt.lessons.Decided(tt.summaries)
+			assert.Equal(t, tt.isErr, err != nil, err)
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}
+
 func TestLessons_Proto(t *testing.T) {
 	t.Parallel()
 	now := jst.Now()

--- a/api/internal/lesson/entity/shift_summary.go
+++ b/api/internal/lesson/entity/shift_summary.go
@@ -23,6 +23,7 @@ const (
 type ShiftSummary struct {
 	ID        int64       `gorm:"primaryKey;autoIncrement;<-:create"`
 	YearMonth int32       `gorm:""`
+	Decided   bool        `gorm:""`
 	Status    ShiftStatus `gorm:"-"`
 	OpenAt    time.Time   `gorm:""`
 	EndAt     time.Time   `gorm:""`
@@ -75,6 +76,7 @@ func (s *ShiftSummary) Proto() *lesson.ShiftSummary {
 	return &lesson.ShiftSummary{
 		Id:        s.ID,
 		YearMonth: s.YearMonth,
+		Decided:   s.Decided,
 		Status:    lesson.ShiftStatus(s.Status),
 		OpenAt:    s.OpenAt.Unix(),
 		EndAt:     s.EndAt.Unix(),

--- a/api/internal/lesson/entity/shift_summary_test.go
+++ b/api/internal/lesson/entity/shift_summary_test.go
@@ -150,6 +150,7 @@ func TestShiftSummary_Fill(t *testing.T) {
 			summary: &ShiftSummary{
 				ID:        1,
 				YearMonth: 202202,
+				Decided:   false,
 				Status:    ShiftStatusUnknown,
 				OpenAt:    jst.Date(2022, 1, 1, 0, 0, 0, 0),
 				EndAt:     jst.Date(2022, 1, 15, 0, 0, 0, 0),
@@ -164,6 +165,7 @@ func TestShiftSummary_Fill(t *testing.T) {
 			summary: &ShiftSummary{
 				ID:        1,
 				YearMonth: 202201,
+				Decided:   false,
 				Status:    ShiftStatusUnknown,
 				OpenAt:    jst.Date(2021, 12, 1, 0, 0, 0, 0),
 				EndAt:     jst.Date(2021, 12, 15, 0, 0, 0, 0),
@@ -178,6 +180,7 @@ func TestShiftSummary_Fill(t *testing.T) {
 			summary: &ShiftSummary{
 				ID:        1,
 				YearMonth: 202112,
+				Decided:   true,
 				Status:    ShiftStatusUnknown,
 				OpenAt:    jst.Date(2021, 11, 1, 0, 0, 0, 0),
 				EndAt:     jst.Date(2021, 11, 15, 0, 0, 0, 0),
@@ -213,6 +216,7 @@ func TestShiftSummary_Proto(t *testing.T) {
 			summary: &ShiftSummary{
 				ID:        1,
 				YearMonth: 202201,
+				Decided:   true,
 				Status:    ShiftStatusAccepting,
 				OpenAt:    jst.Date(2021, 12, 1, 0, 0, 0, 0),
 				EndAt:     jst.Date(2021, 12, 15, 0, 0, 0, 0),
@@ -222,6 +226,7 @@ func TestShiftSummary_Proto(t *testing.T) {
 			expect: &lesson.ShiftSummary{
 				Id:        1,
 				YearMonth: 202201,
+				Decided:   true,
 				Status:    lesson.ShiftStatus_SHIFT_STATUS_ACCEPTING,
 				OpenAt:    jst.Date(2021, 12, 1, 0, 0, 0, 0).Unix(),
 				EndAt:     jst.Date(2021, 12, 15, 0, 0, 0, 0).Unix(),
@@ -256,6 +261,7 @@ func TestShiftSummaries_Map(t *testing.T) {
 				{
 					ID:        1,
 					YearMonth: 202201,
+					Decided:   true,
 					Status:    ShiftStatusAccepting,
 					OpenAt:    jst.Date(2021, 12, 1, 0, 0, 0, 0),
 					EndAt:     jst.Date(2021, 12, 15, 0, 0, 0, 0),
@@ -267,6 +273,7 @@ func TestShiftSummaries_Map(t *testing.T) {
 				1: {
 					ID:        1,
 					YearMonth: 202201,
+					Decided:   true,
 					Status:    ShiftStatusAccepting,
 					OpenAt:    jst.Date(2021, 12, 1, 0, 0, 0, 0),
 					EndAt:     jst.Date(2021, 12, 15, 0, 0, 0, 0),
@@ -302,6 +309,7 @@ func TestShiftSummaries_Fill(t *testing.T) {
 				{
 					ID:        1,
 					YearMonth: 202201,
+					Decided:   true,
 					Status:    ShiftStatusUnknown,
 					OpenAt:    jst.Date(2021, 12, 1, 0, 0, 0, 0),
 					EndAt:     jst.Date(2021, 12, 15, 0, 0, 0, 0),
@@ -313,6 +321,7 @@ func TestShiftSummaries_Fill(t *testing.T) {
 				{
 					ID:        1,
 					YearMonth: 202201,
+					Decided:   true,
 					Status:    ShiftStatusAccepting,
 					OpenAt:    jst.Date(2021, 12, 1, 0, 0, 0, 0),
 					EndAt:     jst.Date(2021, 12, 15, 0, 0, 0, 0),
@@ -349,6 +358,7 @@ func TestShiftSummaries_Proto(t *testing.T) {
 				{
 					ID:        1,
 					YearMonth: 202201,
+					Decided:   true,
 					Status:    ShiftStatusAccepting,
 					OpenAt:    jst.Date(2021, 12, 1, 0, 0, 0, 0),
 					EndAt:     jst.Date(2021, 12, 15, 0, 0, 0, 0),
@@ -360,6 +370,7 @@ func TestShiftSummaries_Proto(t *testing.T) {
 				{
 					Id:        1,
 					YearMonth: 202201,
+					Decided:   true,
 					Status:    lesson.ShiftStatus_SHIFT_STATUS_ACCEPTING,
 					OpenAt:    jst.Date(2021, 12, 1, 0, 0, 0, 0).Unix(),
 					EndAt:     jst.Date(2021, 12, 15, 0, 0, 0, 0).Unix(),

--- a/api/internal/lesson/validation/lesson_test.go
+++ b/api/internal/lesson/validation/lesson_test.go
@@ -24,6 +24,7 @@ func TestListLessons(t *testing.T) {
 				ShiftId:        1,
 				TeacherId:      "teacherid",
 				StudentId:      "studentid",
+				OnlyDecided:    false,
 			},
 			isErr: false,
 		},

--- a/api/mock/lesson/database/database.go
+++ b/api/mock/lesson/database/database.go
@@ -206,6 +206,26 @@ func (mr *MockShiftSummaryMockRecorder) List(ctx, p interface{}, fields ...inter
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockShiftSummary)(nil).List), varargs...)
 }
 
+// MultiGet mocks base method.
+func (m *MockShiftSummary) MultiGet(ctx context.Context, ids []int64, fields ...string) (entity.ShiftSummaries, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, ids}
+	for _, a := range fields {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "MultiGet", varargs...)
+	ret0, _ := ret[0].(entity.ShiftSummaries)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MultiGet indicates an expected call of MultiGet.
+func (mr *MockShiftSummaryMockRecorder) MultiGet(ctx, ids interface{}, fields ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, ids}, fields...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MultiGet", reflect.TypeOf((*MockShiftSummary)(nil).MultiGet), varargs...)
+}
+
 // UpdateSchedule mocks base method.
 func (m *MockShiftSummary) UpdateSchedule(ctx context.Context, id int64, openAt, endAt time.Time) error {
 	m.ctrl.T.Helper()

--- a/api/proto/lesson/service.proto
+++ b/api/proto/lesson/service.proto
@@ -43,6 +43,7 @@ message ListLessonsRequest {
   int64  shift_id         = 2 [(validate.rules).int64 = { gte: 0 }];
   string teacher_id       = 3;
   string student_id       = 4;
+  bool   only_decided     = 5;
 }
 
 message ListLessonsResponse {

--- a/api/proto/lesson/shift_summary.proto
+++ b/api/proto/lesson/shift_summary.proto
@@ -14,4 +14,5 @@ message ShiftSummary {
   int64       end_at     = 5; // 募集締切日時
   int64       created_at = 6; // 登録日時
   int64       updated_at = 7; // 更新日時
+  bool        decided    = 8; // 授業スケジュール確定フラグ
 }

--- a/infra/mysql/schema/2022013001-lessons-aadd-column-to-shift-summaries.sql
+++ b/infra/mysql/schema/2022013001-lessons-aadd-column-to-shift-summaries.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `lessons`.`shift_summaries` ADD COLUMN `decided` TINYINT NOT NULL AFTER `year_month`;


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
授業スケジュール確定有無を管理するためのフィールドを追加しました

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
