### PR TITLE
feat(lesson-api): implement student shift template api

### DIFF
--- a/api/internal/lesson/api/api_test.go
+++ b/api/internal/lesson/api/api_test.go
@@ -35,13 +35,14 @@ type mocks struct {
 }
 
 type dbMocks struct {
-	Lesson            *mock_database.MockLesson
-	ShiftSummary      *mock_database.MockShiftSummary
-	Shift             *mock_database.MockShift
-	TeacherSubmission *mock_database.MockTeacherSubmission
-	TeacherShift      *mock_database.MockTeacherShift
-	StudentSubmission *mock_database.MockStudentSubmission
-	StudentShift      *mock_database.MockStudentShift
+	Lesson               *mock_database.MockLesson
+	ShiftSummary         *mock_database.MockShiftSummary
+	Shift                *mock_database.MockShift
+	TeacherSubmission    *mock_database.MockTeacherSubmission
+	TeacherShift         *mock_database.MockTeacherShift
+	StudentSubmission    *mock_database.MockStudentSubmission
+	StudentShift         *mock_database.MockStudentShift
+	StudentShiftTemplate *mock_database.MockStudentShiftTemplate
 }
 
 type testResponse struct {
@@ -67,13 +68,14 @@ func newMocks(ctrl *gomock.Controller) *mocks {
 
 func newDBMocks(ctrl *gomock.Controller) *dbMocks {
 	return &dbMocks{
-		Lesson:            mock_database.NewMockLesson(ctrl),
-		ShiftSummary:      mock_database.NewMockShiftSummary(ctrl),
-		Shift:             mock_database.NewMockShift(ctrl),
-		TeacherSubmission: mock_database.NewMockTeacherSubmission(ctrl),
-		TeacherShift:      mock_database.NewMockTeacherShift(ctrl),
-		StudentSubmission: mock_database.NewMockStudentSubmission(ctrl),
-		StudentShift:      mock_database.NewMockStudentShift(ctrl),
+		Lesson:               mock_database.NewMockLesson(ctrl),
+		ShiftSummary:         mock_database.NewMockShiftSummary(ctrl),
+		Shift:                mock_database.NewMockShift(ctrl),
+		TeacherSubmission:    mock_database.NewMockTeacherSubmission(ctrl),
+		TeacherShift:         mock_database.NewMockTeacherShift(ctrl),
+		StudentSubmission:    mock_database.NewMockStudentSubmission(ctrl),
+		StudentShift:         mock_database.NewMockStudentShift(ctrl),
+		StudentShiftTemplate: mock_database.NewMockStudentShiftTemplate(ctrl),
 	}
 }
 
@@ -84,13 +86,14 @@ func newLessonService(mocks *mocks, opts *testOptions) *lessonService {
 		sharedGroup: &singleflight.Group{},
 		waitGroup:   &sync.WaitGroup{},
 		db: &database.Database{
-			Lesson:            mocks.db.Lesson,
-			ShiftSummary:      mocks.db.ShiftSummary,
-			Shift:             mocks.db.Shift,
-			TeacherSubmission: mocks.db.TeacherSubmission,
-			TeacherShift:      mocks.db.TeacherShift,
-			StudentSubmission: mocks.db.StudentSubmission,
-			StudentShift:      mocks.db.StudentShift,
+			Lesson:               mocks.db.Lesson,
+			ShiftSummary:         mocks.db.ShiftSummary,
+			Shift:                mocks.db.Shift,
+			TeacherSubmission:    mocks.db.TeacherSubmission,
+			TeacherShift:         mocks.db.TeacherShift,
+			StudentSubmission:    mocks.db.StudentSubmission,
+			StudentShift:         mocks.db.StudentShift,
+			StudentShiftTemplate: mocks.db.StudentShiftTemplate,
 		},
 		validator: mocks.validator,
 		classroom: mocks.classroom,

--- a/api/internal/lesson/api/student_shift.go
+++ b/api/internal/lesson/api/student_shift.go
@@ -173,6 +173,44 @@ func (s *lessonService) UpsertStudentShifts(
 	return res, nil
 }
 
+func (s *lessonService) GetStudentShiftTemplate(
+	ctx context.Context, req *lesson.GetStudentShiftTemplateRequest,
+) (*lesson.GetStudentShiftTemplateResponse, error) {
+	if err := s.validator.GetStudentShiftTemplate(req); err != nil {
+		return nil, gRPCError(err)
+	}
+
+	template, err := s.db.StudentShiftTemplate.Get(ctx, req.StudentId)
+	if err != nil {
+		return nil, gRPCError(err)
+	}
+
+	res := &lesson.GetStudentShiftTemplateResponse{
+		Template: template.Proto(),
+	}
+	return res, nil
+}
+
+func (s *lessonService) UpsertStudentShiftTemplate(
+	ctx context.Context, req *lesson.UpsertStudentShiftTemplateRequest,
+) (*lesson.UpsertStudentShiftTemplateResponse, error) {
+	if err := s.validator.UpsertStudentShiftTemplate(req); err != nil {
+		return nil, gRPCError(err)
+	}
+
+	in := &user.GetStudentRequest{Id: req.StudentId}
+	if _, err := s.user.GetStudent(ctx, in); err != nil {
+		return nil, gRPCError(err)
+	}
+
+	template := entity.NewStudentShiftTemplate(req.StudentId, req.Template)
+	if err := s.db.StudentShiftTemplate.Upsert(ctx, req.StudentId, template); err != nil {
+		return nil, gRPCError(err)
+	}
+
+	return &lesson.UpsertStudentShiftTemplateResponse{}, nil
+}
+
 func (s *lessonService) isContainsStudentSubjects(
 	subject *classroom.StudentSubject, lessons entity.SuggestedLessons,
 ) bool {

--- a/api/internal/lesson/api/student_shift_test.go
+++ b/api/internal/lesson/api/student_shift_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/proto"
+	"gorm.io/datatypes"
 )
 
 func TestListStudentSubmissionsByShiftSummaryID(t *testing.T) {
@@ -733,6 +734,202 @@ func TestUpsertStudentShifts(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, testGRPC(tt.setup, tt.expect, func(ctx context.Context, service *lessonService) (proto.Message, error) {
 			return service.UpsertStudentShifts(ctx, tt.req)
+		}))
+	}
+}
+
+func TestGetStudentShiftTempalte(t *testing.T) {
+	t.Parallel()
+	now := jst.Now()
+	req := &lesson.GetStudentShiftTemplateRequest{
+		StudentId: "studentid",
+	}
+	template := &entity.StudentShiftTemplate{
+		StudentID: "studentid",
+		Schedules: entity.ShiftSchedules{
+			{
+				Weekday: time.Sunday,
+				Lessons: entity.LessonSchedules{
+					{StartTime: "1700", EndTime: "1830"},
+					{StartTime: "1830", EndTime: "2000"},
+				},
+			},
+		},
+		SchedulesJSON: datatypes.JSON([]byte(`[{"weekday":0,"lessons":[{"startTime":"1700","endTime":"1830"},{"startTime":"1830","endTime":"2000"}]}]`)),
+		SuggestedLessons: entity.SuggestedLessons{
+			{SubjectID: 1, Total: 4},
+		},
+		SuggestedLessonsJSON: datatypes.JSON([]byte(`[{"subjectId":1,"total":4}]`)),
+		CreatedAt:            now,
+		UpdatedAt:            now,
+	}
+	tests := []struct {
+		name   string
+		setup  func(ctx context.Context, t *testing.T, mocks *mocks)
+		req    *lesson.GetStudentShiftTemplateRequest
+		expect *testResponse
+	}{
+		{
+			name: "success",
+			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
+				mocks.validator.EXPECT().GetStudentShiftTemplate(req).Return(nil)
+				mocks.db.StudentShiftTemplate.EXPECT().Get(ctx, "studentid").Return(template, nil)
+			},
+			req: req,
+			expect: &testResponse{
+				code: codes.OK,
+				body: &lesson.GetStudentShiftTemplateResponse{
+					Template: &lesson.StudentShiftTemplate{
+						StudentId: "studentid",
+						Schedules: []*lesson.ShiftSchedule{
+							{
+								Weekday: int32(time.Sunday),
+								Lessons: []*lesson.LessonSchedule{
+									{StartTime: "1700", EndTime: "1830"},
+									{StartTime: "1830", EndTime: "2000"},
+								},
+							},
+						},
+						SuggesteLessons: []*lesson.SuggestedLesson{
+							{SubjectId: 1, Total: 4},
+						},
+						CreatedAt: now.Unix(),
+						UpdatedAt: now.Unix(),
+					},
+				},
+			},
+		},
+		{
+			name: "failed to invalid argument",
+			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
+				req := &lesson.GetStudentShiftTemplateRequest{}
+				mocks.validator.EXPECT().GetStudentShiftTemplate(req).Return(validation.ErrRequestValidation)
+			},
+			req: &lesson.GetStudentShiftTemplateRequest{},
+			expect: &testResponse{
+				code: codes.InvalidArgument,
+			},
+		},
+		{
+			name: "failed to get student shift template",
+			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
+				mocks.validator.EXPECT().GetStudentShiftTemplate(req).Return(nil)
+				mocks.db.StudentShiftTemplate.EXPECT().Get(ctx, "studentid").Return(nil, errmock)
+			},
+			req: req,
+			expect: &testResponse{
+				code: codes.Internal,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, testGRPC(tt.setup, tt.expect, func(ctx context.Context, service *lessonService) (proto.Message, error) {
+			return service.GetStudentShiftTemplate(ctx, tt.req)
+		}))
+	}
+}
+
+func TestUpsertStudentShiftTempalte(t *testing.T) {
+	t.Parallel()
+	req := &lesson.UpsertStudentShiftTemplateRequest{
+		StudentId: "studentid",
+		Template: &lesson.StudentShiftTemplateToUpsert{
+			Schedules: []*lesson.StudentShiftTemplateToUpsert_Schedule{
+				{
+					Weekday: int32(time.Sunday),
+					Lessons: []*lesson.StudentShiftTemplateToUpsert_Lesson{
+						{StartTime: "1700", EndTime: "1830"},
+						{StartTime: "1830", EndTime: "2000"},
+					},
+				},
+			},
+			SuggestedLessons: []*lesson.StudentSuggestedLesson{
+				{SubjectId: 1, Total: 4},
+			},
+		},
+	}
+	student := &user.Student{Id: "studentid"}
+	template := &entity.StudentShiftTemplate{
+		StudentID: "studentid",
+		Schedules: entity.ShiftSchedules{
+			{
+				Weekday: time.Sunday,
+				Lessons: entity.LessonSchedules{
+					{StartTime: "1700", EndTime: "1830"},
+					{StartTime: "1830", EndTime: "2000"},
+				},
+			},
+		},
+		SuggestedLessons: entity.SuggestedLessons{
+			{SubjectID: 1, Total: 4},
+		},
+	}
+	tests := []struct {
+		name   string
+		setup  func(ctx context.Context, t *testing.T, mocks *mocks)
+		req    *lesson.UpsertStudentShiftTemplateRequest
+		expect *testResponse
+	}{
+		{
+			name: "success",
+			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
+				in := &user.GetStudentRequest{Id: "studentid"}
+				out := &user.GetStudentResponse{Student: student}
+				mocks.validator.EXPECT().UpsertStudentShiftTemplate(req).Return(nil)
+				mocks.user.EXPECT().GetStudent(ctx, in).Return(out, nil)
+				mocks.db.StudentShiftTemplate.EXPECT().Upsert(ctx, "studentid", template).Return(nil)
+			},
+			req: req,
+			expect: &testResponse{
+				code: codes.OK,
+				body: &lesson.UpsertStudentShiftTemplateResponse{},
+			},
+		},
+		{
+			name: "failed to invalid argument",
+			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
+				req := &lesson.UpsertStudentShiftTemplateRequest{}
+				mocks.validator.EXPECT().UpsertStudentShiftTemplate(req).Return(validation.ErrRequestValidation)
+			},
+			req: &lesson.UpsertStudentShiftTemplateRequest{},
+			expect: &testResponse{
+				code: codes.InvalidArgument,
+			},
+		},
+		{
+			name: "failed to get student",
+			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
+				in := &user.GetStudentRequest{Id: "studentid"}
+				mocks.validator.EXPECT().UpsertStudentShiftTemplate(req).Return(nil)
+				mocks.user.EXPECT().GetStudent(ctx, in).Return(nil, errmock)
+			},
+			req: req,
+			expect: &testResponse{
+				code: codes.Internal,
+			},
+		},
+		{
+			name: "failed to get student shift template",
+			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
+				in := &user.GetStudentRequest{Id: "studentid"}
+				out := &user.GetStudentResponse{Student: student}
+				mocks.validator.EXPECT().UpsertStudentShiftTemplate(req).Return(nil)
+				mocks.user.EXPECT().GetStudent(ctx, in).Return(out, nil)
+				mocks.db.StudentShiftTemplate.EXPECT().Upsert(ctx, "studentid", template).Return(errmock)
+			},
+			req: req,
+			expect: &testResponse{
+				code: codes.Internal,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, testGRPC(tt.setup, tt.expect, func(ctx context.Context, service *lessonService) (proto.Message, error) {
+			return service.UpsertStudentShiftTemplate(ctx, tt.req)
 		}))
 	}
 }

--- a/api/internal/lesson/database/database.go
+++ b/api/internal/lesson/database/database.go
@@ -28,24 +28,26 @@ type Params struct {
 }
 
 type Database struct {
-	Lesson            Lesson
-	ShiftSummary      ShiftSummary
-	Shift             Shift
-	TeacherSubmission TeacherSubmission
-	TeacherShift      TeacherShift
-	StudentSubmission StudentSubmission
-	StudentShift      StudentShift
+	Lesson               Lesson
+	ShiftSummary         ShiftSummary
+	Shift                Shift
+	TeacherSubmission    TeacherSubmission
+	TeacherShift         TeacherShift
+	StudentSubmission    StudentSubmission
+	StudentShift         StudentShift
+	StudentShiftTemplate StudentShiftTemplate
 }
 
 func NewDatabase(params *Params) *Database {
 	return &Database{
-		Lesson:            NewLesson(params.Database),
-		ShiftSummary:      NewShiftSummary(params.Database),
-		Shift:             NewShift(params.Database),
-		TeacherSubmission: NewTeacherSubmission(params.Database),
-		TeacherShift:      NewTeacherShift(params.Database),
-		StudentSubmission: NewStudentSubmission(params.Database),
-		StudentShift:      NewStudentShift(params.Database),
+		Lesson:               NewLesson(params.Database),
+		ShiftSummary:         NewShiftSummary(params.Database),
+		Shift:                NewShift(params.Database),
+		TeacherSubmission:    NewTeacherSubmission(params.Database),
+		TeacherShift:         NewTeacherShift(params.Database),
+		StudentSubmission:    NewStudentSubmission(params.Database),
+		StudentShift:         NewStudentShift(params.Database),
+		StudentShiftTemplate: NewStudentShiftTemplate(params.Database),
 	}
 }
 
@@ -109,6 +111,11 @@ type StudentShift interface {
 	) (entity.StudentShifts, error)
 	ListByShiftID(ctx context.Context, shiftID int64, fields ...string) (entity.StudentShifts, error)
 	Replace(ctx context.Context, submission *entity.StudentSubmission, shifts entity.StudentShifts) error
+}
+
+type StudentShiftTemplate interface {
+	Get(ctx context.Context, studentID string) (*entity.StudentShiftTemplate, error)
+	Upsert(ctx context.Context, studentID string, template *entity.StudentShiftTemplate) error
 }
 
 /**

--- a/api/internal/lesson/database/student_shift_template.go
+++ b/api/internal/lesson/database/student_shift_template.go
@@ -1,0 +1,90 @@
+package database
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/calmato/shs-web/api/internal/lesson/entity"
+	"github.com/calmato/shs-web/api/pkg/database"
+	"github.com/calmato/shs-web/api/pkg/jst"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const studentShiftTemplateTable = "student_shift_templates"
+
+var studentShiftTemplateFields = []string{
+	"student_id", "schedules", "suggested_lessons", "created_at", "updated_at",
+}
+
+type studentShiftTemplate struct {
+	db  *database.Client
+	now func() time.Time
+}
+
+func NewStudentShiftTemplate(db *database.Client) StudentShiftTemplate {
+	return &studentShiftTemplate{
+		db:  db,
+		now: jst.Now,
+	}
+}
+
+func (s *studentShiftTemplate) Get(ctx context.Context, studentID string) (*entity.StudentShiftTemplate, error) {
+	var template *entity.StudentShiftTemplate
+
+	stmt := s.db.DB.Table(studentShiftTemplateTable).
+		Select(studentShiftTemplateFields).
+		Where("student_id", studentID)
+
+	err := stmt.First(&template).Error
+	if err != nil {
+		return nil, dbError(err)
+	}
+	err = template.Fill()
+	if err != nil {
+		return nil, dbError(err)
+	}
+	return template, nil
+}
+
+func (s *studentShiftTemplate) Upsert(
+	ctx context.Context, studentID string, template *entity.StudentShiftTemplate,
+) error {
+	now := s.now()
+	err := template.FillJSON()
+	if err != nil {
+		return dbError(err)
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return dbError(err)
+	}
+	defer s.db.Close(tx)
+
+	var current *entity.StudentShiftTemplate
+	err = tx.Table(studentShiftTemplateTable).
+		Select([]string{"student_id", "created_at"}).
+		Where("student_id = ?", studentID).
+		First(&current).Error
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return dbError(err)
+	}
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		template.CreatedAt = now
+		template.UpdatedAt = now
+	} else {
+		template.CreatedAt = current.CreatedAt
+		template.UpdatedAt = now
+	}
+
+	err = tx.Clauses(clause.OnConflict{UpdateAll: true}).
+		Table(studentShiftTemplateTable).
+		Create(&template).Error
+	if err != nil {
+		tx.Rollback()
+		return dbError(err)
+	}
+	return dbError(tx.Commit().Error)
+}

--- a/api/internal/lesson/database/student_shift_template_test.go
+++ b/api/internal/lesson/database/student_shift_template_test.go
@@ -1,0 +1,177 @@
+package database
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/calmato/shs-web/api/internal/lesson/entity"
+	"github.com/calmato/shs-web/api/pkg/jst"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStudentShiftTemplate_Get(t *testing.T) {
+	m, err := newMock()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_ = m.dbDelete(ctx, studentShiftTemplateTable)
+
+	now := jst.Date(2021, 12, 10, 12, 0, 0, 0)
+
+	const studentID = "studentid"
+	template := testStudentShiftTemplate(studentID, now)
+	err = m.db.DB.Create(&template).Error
+	require.NoError(t, err)
+
+	type args struct {
+		studentID string
+	}
+	type want struct {
+		template *entity.StudentShiftTemplate
+		isErr    bool
+	}
+	tests := []struct {
+		name  string
+		setup func(ctx context.Context, t *testing.T, m *mocks)
+		args  args
+		want  want
+	}{
+		{
+			name:  "success",
+			setup: func(ctx context.Context, t *testing.T, m *mocks) {},
+			args: args{
+				studentID: studentID,
+			},
+			want: want{
+				template: template,
+				isErr:    false,
+			},
+		},
+		{
+			name:  "not found",
+			setup: func(ctx context.Context, t *testing.T, m *mocks) {},
+			args: args{
+				studentID: "",
+			},
+			want: want{
+				template: nil,
+				isErr:    true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			tt.setup(ctx, t, m)
+
+			db := NewStudentShiftTemplate(m.db)
+			actual, err := db.Get(ctx, tt.args.studentID)
+			if tt.want.isErr {
+				assert.Error(t, err)
+				return
+			}
+			tt.want.template.CreatedAt, tt.want.template.UpdatedAt = actual.CreatedAt, actual.UpdatedAt
+			tt.want.template.SchedulesJSON = actual.SchedulesJSON
+			tt.want.template.SuggestedLessonsJSON = actual.SuggestedLessonsJSON
+			assert.NoError(t, err)
+			assert.Equal(t, actual, tt.want.template)
+		})
+	}
+}
+
+func TestStudentShiftTemplate_Upsert(t *testing.T) {
+	m, err := newMock()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_ = m.dbDelete(ctx, studentShiftTemplateTable)
+
+	now := jst.Date(2021, 12, 10, 12, 0, 0, 0)
+
+	const studentID = "studentid"
+	template := testStudentShiftTemplate(studentID, now)
+
+	type args struct {
+		studentID string
+		template  *entity.StudentShiftTemplate
+	}
+	type want struct {
+		isErr bool
+	}
+	tests := []struct {
+		name  string
+		setup func(ctx context.Context, t *testing.T, m *mocks)
+		args  args
+		want  want
+	}{
+		{
+			name:  "success to create",
+			setup: func(ctx context.Context, t *testing.T, m *mocks) {},
+			args: args{
+				studentID: studentID,
+				template:  template,
+			},
+			want: want{
+				isErr: false,
+			},
+		},
+		{
+			name: "success to update",
+			setup: func(ctx context.Context, t *testing.T, m *mocks) {
+				err := m.db.DB.Create(&template).Error
+				require.NoError(t, err)
+			},
+			args: args{
+				studentID: studentID,
+				template:  template,
+			},
+			want: want{
+				isErr: false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			m.dbDelete(ctx, studentShiftTemplateTable)
+			tt.setup(ctx, t, m)
+
+			db := NewStudentShiftTemplate(m.db)
+			err := db.Upsert(ctx, tt.args.studentID, tt.args.template)
+			assert.Equal(t, tt.want.isErr, err != nil, err)
+		})
+	}
+}
+
+func testStudentShiftTemplate(studentID string, now time.Time) *entity.StudentShiftTemplate {
+	template := &entity.StudentShiftTemplate{
+		StudentID: studentID,
+		Schedules: entity.ShiftSchedules{
+			{
+				Weekday: time.Sunday,
+				Lessons: entity.LessonSchedules{
+					{StartTime: "1700", EndTime: "1830"},
+					{StartTime: "1830", EndTime: "2000"},
+				},
+			},
+		},
+		SuggestedLessons: entity.SuggestedLessons{
+			{SubjectID: 1, Total: 4},
+		},
+	}
+	_ = template.FillJSON()
+	return template
+}

--- a/api/internal/lesson/entity/student_shift_template.go
+++ b/api/internal/lesson/entity/student_shift_template.go
@@ -1,0 +1,160 @@
+package entity
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/calmato/shs-web/api/proto/lesson"
+	"gorm.io/datatypes"
+)
+
+type StudentShiftTemplate struct {
+	StudentID            string           `gorm:"primaryKey;<-:create"`
+	Schedules            ShiftSchedules   `gorm:"-"`
+	SchedulesJSON        datatypes.JSON   `gorm:"column:schedules"`
+	SuggestedLessons     SuggestedLessons `gorm:"-"`
+	SuggestedLessonsJSON datatypes.JSON   `gorm:"column:suggested_lessons"`
+	CreatedAt            time.Time        `gorm:"<-:create"`
+	UpdatedAt            time.Time        `gorm:""`
+}
+
+type ShiftSchedule struct {
+	Weekday time.Weekday    `json:"weekday"`
+	Lessons LessonSchedules `json:"lessons"`
+}
+
+type ShiftSchedules []*ShiftSchedule
+
+type LessonSchedule struct {
+	StartTime string `json:"startTime"`
+	EndTime   string `json:"endTime"`
+}
+
+type LessonSchedules []*LessonSchedule
+
+func NewStudentShiftTemplate(studentID string, template *lesson.StudentShiftTemplateToUpsert) *StudentShiftTemplate {
+	return &StudentShiftTemplate{
+		StudentID:        studentID,
+		Schedules:        newShiftSchedules(template.Schedules),
+		SuggestedLessons: NewSuggestedLessons(template.SuggestedLessons),
+	}
+}
+
+func newShiftSchedule(schedule *lesson.StudentShiftTemplateToUpsert_Schedule) *ShiftSchedule {
+	return &ShiftSchedule{
+		Weekday: time.Weekday(schedule.Weekday),
+		Lessons: newLessonSchedules(schedule.Lessons),
+	}
+}
+
+func newShiftSchedules(schedules []*lesson.StudentShiftTemplateToUpsert_Schedule) ShiftSchedules {
+	res := make(ShiftSchedules, len(schedules))
+	for i := range schedules {
+		res[i] = newShiftSchedule(schedules[i])
+	}
+	return res
+}
+
+func newLessonSchedule(lesson *lesson.StudentShiftTemplateToUpsert_Lesson) *LessonSchedule {
+	return &LessonSchedule{
+		StartTime: lesson.StartTime,
+		EndTime:   lesson.EndTime,
+	}
+}
+
+func newLessonSchedules(lessons []*lesson.StudentShiftTemplateToUpsert_Lesson) LessonSchedules {
+	res := make(LessonSchedules, len(lessons))
+	for i := range lessons {
+		res[i] = newLessonSchedule(lessons[i])
+	}
+	return res
+}
+
+func (t *StudentShiftTemplate) Fill() error {
+	if err := t.fillSchedules(); err != nil {
+		return err
+	}
+	if err := t.fillSuggestedLessons(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *StudentShiftTemplate) fillSchedules() error {
+	var schedules ShiftSchedules
+	if err := json.Unmarshal(t.SchedulesJSON, &schedules); err != nil {
+		return err
+	}
+	t.Schedules = schedules
+	return nil
+}
+
+func (t *StudentShiftTemplate) fillSuggestedLessons() error {
+	var lessons SuggestedLessons
+	if err := json.Unmarshal(t.SuggestedLessonsJSON, &lessons); err != nil {
+		return err
+	}
+	t.SuggestedLessons = lessons
+	return nil
+}
+
+func (t *StudentShiftTemplate) FillJSON() error {
+	if err := t.fillSchedulesJSON(); err != nil {
+		return err
+	}
+	if err := t.fillSuggestedLessonsJSON(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *StudentShiftTemplate) fillSchedulesJSON() error {
+	v, err := json.Marshal(t.Schedules)
+	if err != nil {
+		return err
+	}
+	t.SchedulesJSON = datatypes.JSON(v)
+	return nil
+}
+
+func (t *StudentShiftTemplate) fillSuggestedLessonsJSON() error {
+	v, err := json.Marshal(t.SuggestedLessons)
+	if err != nil {
+		return err
+	}
+	t.SuggestedLessonsJSON = datatypes.JSON(v)
+	return nil
+}
+
+func (t *StudentShiftTemplate) Proto() *lesson.StudentShiftTemplate {
+	return &lesson.StudentShiftTemplate{
+		StudentId:       t.StudentID,
+		Schedules:       t.Schedules.Proto(),
+		SuggesteLessons: t.SuggestedLessons.Proto(),
+		CreatedAt:       t.CreatedAt.Unix(),
+		UpdatedAt:       t.UpdatedAt.Unix(),
+	}
+}
+
+func (s *ShiftSchedule) Proto() *lesson.ShiftSchedule {
+	lessons := make([]*lesson.LessonSchedule, len(s.Lessons))
+	for i := range s.Lessons {
+		lessons[i] = &lesson.LessonSchedule{
+			StartTime: s.Lessons[i].StartTime,
+			EndTime:   s.Lessons[i].EndTime,
+		}
+	}
+
+	return &lesson.ShiftSchedule{
+		Weekday: int32(s.Weekday),
+		Lessons: lessons,
+	}
+}
+
+func (ss ShiftSchedules) Proto() []*lesson.ShiftSchedule {
+	res := make([]*lesson.ShiftSchedule, len(ss))
+	for i := range ss {
+		res[i] = ss[i].Proto()
+	}
+	return res
+}

--- a/api/internal/lesson/entity/student_shift_template_test.go
+++ b/api/internal/lesson/entity/student_shift_template_test.go
@@ -1,0 +1,225 @@
+package entity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/calmato/shs-web/api/pkg/jst"
+	"github.com/calmato/shs-web/api/proto/lesson"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/datatypes"
+)
+
+func TestStudentShiftTemplate(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		studentID string
+		template  *lesson.StudentShiftTemplateToUpsert
+		expect    *StudentShiftTemplate
+	}{
+		{
+			name:      "success",
+			studentID: "studentid",
+			template: &lesson.StudentShiftTemplateToUpsert{
+				Schedules: []*lesson.StudentShiftTemplateToUpsert_Schedule{
+					{
+						Weekday: int32(time.Sunday),
+						Lessons: []*lesson.StudentShiftTemplateToUpsert_Lesson{
+							{StartTime: "1700", EndTime: "1830"},
+							{StartTime: "1830", EndTime: "2000"},
+						},
+					},
+				},
+				SuggestedLessons: []*lesson.StudentSuggestedLesson{
+					{SubjectId: 1, Total: 4},
+				},
+			},
+			expect: &StudentShiftTemplate{
+				StudentID: "studentid",
+				Schedules: ShiftSchedules{
+					{
+						Weekday: time.Sunday,
+						Lessons: LessonSchedules{
+							{StartTime: "1700", EndTime: "1830"},
+							{StartTime: "1830", EndTime: "2000"},
+						},
+					},
+				},
+				SuggestedLessons: SuggestedLessons{
+					{SubjectID: 1, Total: 4},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, NewStudentShiftTemplate(tt.studentID, tt.template))
+		})
+	}
+}
+
+func TestStudentShiftTemplate_Fill(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		template *StudentShiftTemplate
+		expect   *StudentShiftTemplate
+		isErr    bool
+	}{
+		{
+			name: "success",
+			template: &StudentShiftTemplate{
+				StudentID:            "studentid",
+				SchedulesJSON:        datatypes.JSON([]byte(`[{"weekday":0,"lessons":[{"startTime":"1700","endTime":"1830"},{"startTime":"1830","endTime":"2000"}]}]`)),
+				SuggestedLessonsJSON: datatypes.JSON([]byte(`[{"subjectId":1,"total":4}]`)),
+			},
+			expect: &StudentShiftTemplate{
+				StudentID: "studentid",
+				Schedules: ShiftSchedules{
+					{
+						Weekday: time.Sunday,
+						Lessons: LessonSchedules{
+							{StartTime: "1700", EndTime: "1830"},
+							{StartTime: "1830", EndTime: "2000"},
+						},
+					},
+				},
+				SchedulesJSON: datatypes.JSON([]byte(`[{"weekday":0,"lessons":[{"startTime":"1700","endTime":"1830"},{"startTime":"1830","endTime":"2000"}]}]`)),
+				SuggestedLessons: SuggestedLessons{
+					{SubjectID: 1, Total: 4},
+				},
+				SuggestedLessonsJSON: datatypes.JSON([]byte(`[{"subjectId":1,"total":4}]`)),
+			},
+			isErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.template.Fill()
+			assert.Equal(t, tt.isErr, err != nil, err)
+			assert.Equal(t, tt.expect, tt.template)
+		})
+	}
+}
+
+func TestStudentShiftTemplate_FillJSON(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		template *StudentShiftTemplate
+		expect   *StudentShiftTemplate
+		isErr    bool
+	}{
+		{
+			name: "success",
+			template: &StudentShiftTemplate{
+				StudentID: "studentid",
+				Schedules: ShiftSchedules{
+					{
+						Weekday: time.Sunday,
+						Lessons: LessonSchedules{
+							{StartTime: "1700", EndTime: "1830"},
+							{StartTime: "1830", EndTime: "2000"},
+						},
+					},
+				},
+				SuggestedLessons: SuggestedLessons{
+					{SubjectID: 1, Total: 4},
+				},
+			},
+			expect: &StudentShiftTemplate{
+				StudentID: "studentid",
+				Schedules: ShiftSchedules{
+					{
+						Weekday: time.Sunday,
+						Lessons: LessonSchedules{
+							{StartTime: "1700", EndTime: "1830"},
+							{StartTime: "1830", EndTime: "2000"},
+						},
+					},
+				},
+				SchedulesJSON: datatypes.JSON([]byte(`[{"weekday":0,"lessons":[{"startTime":"1700","endTime":"1830"},{"startTime":"1830","endTime":"2000"}]}]`)),
+				SuggestedLessons: SuggestedLessons{
+					{SubjectID: 1, Total: 4},
+				},
+				SuggestedLessonsJSON: datatypes.JSON([]byte(`[{"subjectId":1,"total":4}]`)),
+			},
+			isErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.template.FillJSON()
+			assert.Equal(t, tt.isErr, err != nil, err)
+			assert.Equal(t, tt.expect, tt.template)
+		})
+	}
+}
+
+func TestStudentShiftTemplate_Proto(t *testing.T) {
+	t.Parallel()
+	now := jst.Date(2022, 1, 2, 18, 30, 0, 0)
+	tests := []struct {
+		name     string
+		template *StudentShiftTemplate
+		expect   *lesson.StudentShiftTemplate
+	}{
+		{
+			name: "success",
+			template: &StudentShiftTemplate{
+				StudentID: "studentid",
+				Schedules: ShiftSchedules{
+					{
+						Weekday: time.Sunday,
+						Lessons: LessonSchedules{
+							{StartTime: "1700", EndTime: "1830"},
+							{StartTime: "1830", EndTime: "2000"},
+						},
+					},
+				},
+				SchedulesJSON: datatypes.JSON([]byte(`[{"weekday":0,"lessons":[{"startTime":"1700","endTime":"1830"},{"startTime":"1830","endTime":"2000"}]}]`)),
+				SuggestedLessons: SuggestedLessons{
+					{SubjectID: 1, Total: 4},
+				},
+				SuggestedLessonsJSON: datatypes.JSON([]byte(`[{"subjectId":1,"total":4}]`)),
+				CreatedAt:            now,
+				UpdatedAt:            now,
+			},
+			expect: &lesson.StudentShiftTemplate{
+				StudentId: "studentid",
+				Schedules: []*lesson.ShiftSchedule{
+					{
+						Weekday: int32(time.Sunday),
+						Lessons: []*lesson.LessonSchedule{
+							{StartTime: "1700", EndTime: "1830"},
+							{StartTime: "1830", EndTime: "2000"},
+						},
+					},
+				},
+				SuggesteLessons: []*lesson.SuggestedLesson{
+					{SubjectId: 1, Total: 4},
+				},
+				CreatedAt: now.Unix(),
+				UpdatedAt: now.Unix(),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.template.Proto())
+		})
+	}
+}

--- a/api/internal/lesson/validation/student_shift.go
+++ b/api/internal/lesson/validation/student_shift.go
@@ -50,3 +50,21 @@ func (v *requestValidation) UpsertStudentShifts(req *lesson.UpsertStudentShiftsR
 
 	return nil
 }
+
+func (v *requestValidation) GetStudentShiftTemplate(req *lesson.GetStudentShiftTemplateRequest) error {
+	if err := req.Validate(); err != nil {
+		validate := err.(lesson.GetStudentShiftTemplateRequestValidationError)
+		return validationError(validate.Error())
+	}
+
+	return nil
+}
+
+func (v *requestValidation) UpsertStudentShiftTemplate(req *lesson.UpsertStudentShiftTemplateRequest) error {
+	if err := req.Validate(); err != nil {
+		validate := err.(lesson.UpsertStudentShiftTemplateRequestValidationError)
+		return validationError(validate.Error())
+	}
+
+	return nil
+}

--- a/api/internal/lesson/validation/validator.go
+++ b/api/internal/lesson/validation/validator.go
@@ -34,6 +34,8 @@ type RequestValidation interface {
 	ListStudentShifts(req *lesson.ListStudentShiftsRequest) error
 	GetStudentShifts(req *lesson.GetStudentShiftsRequest) error
 	UpsertStudentShifts(req *lesson.UpsertStudentShiftsRequest) error
+	GetStudentShiftTemplate(req *lesson.GetStudentShiftTemplateRequest) error
+	UpsertStudentShiftTemplate(req *lesson.UpsertStudentShiftTemplateRequest) error
 }
 
 type requestValidation struct{}

--- a/api/mock/lesson/database/database.go
+++ b/api/mock/lesson/database/database.go
@@ -670,3 +670,55 @@ func (mr *MockStudentShiftMockRecorder) Replace(ctx, submission, shifts interfac
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Replace", reflect.TypeOf((*MockStudentShift)(nil).Replace), ctx, submission, shifts)
 }
+
+// MockStudentShiftTemplate is a mock of StudentShiftTemplate interface.
+type MockStudentShiftTemplate struct {
+	ctrl     *gomock.Controller
+	recorder *MockStudentShiftTemplateMockRecorder
+}
+
+// MockStudentShiftTemplateMockRecorder is the mock recorder for MockStudentShiftTemplate.
+type MockStudentShiftTemplateMockRecorder struct {
+	mock *MockStudentShiftTemplate
+}
+
+// NewMockStudentShiftTemplate creates a new mock instance.
+func NewMockStudentShiftTemplate(ctrl *gomock.Controller) *MockStudentShiftTemplate {
+	mock := &MockStudentShiftTemplate{ctrl: ctrl}
+	mock.recorder = &MockStudentShiftTemplateMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockStudentShiftTemplate) EXPECT() *MockStudentShiftTemplateMockRecorder {
+	return m.recorder
+}
+
+// Get mocks base method.
+func (m *MockStudentShiftTemplate) Get(ctx context.Context, studentID string) (*entity.StudentShiftTemplate, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", ctx, studentID)
+	ret0, _ := ret[0].(*entity.StudentShiftTemplate)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockStudentShiftTemplateMockRecorder) Get(ctx, studentID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockStudentShiftTemplate)(nil).Get), ctx, studentID)
+}
+
+// Upsert mocks base method.
+func (m *MockStudentShiftTemplate) Upsert(ctx context.Context, studentID string, template *entity.StudentShiftTemplate) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Upsert", ctx, studentID, template)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Upsert indicates an expected call of Upsert.
+func (mr *MockStudentShiftTemplateMockRecorder) Upsert(ctx, studentID, template interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upsert", reflect.TypeOf((*MockStudentShiftTemplate)(nil).Upsert), ctx, studentID, template)
+}

--- a/api/mock/lesson/validation/validator.go
+++ b/api/mock/lesson/validation/validator.go
@@ -104,6 +104,20 @@ func (mr *MockRequestValidationMockRecorder) GetShiftSummary(req interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShiftSummary", reflect.TypeOf((*MockRequestValidation)(nil).GetShiftSummary), req)
 }
 
+// GetStudentShiftTemplate mocks base method.
+func (m *MockRequestValidation) GetStudentShiftTemplate(req *lesson.GetStudentShiftTemplateRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetStudentShiftTemplate", req)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GetStudentShiftTemplate indicates an expected call of GetStudentShiftTemplate.
+func (mr *MockRequestValidationMockRecorder) GetStudentShiftTemplate(req interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStudentShiftTemplate", reflect.TypeOf((*MockRequestValidation)(nil).GetStudentShiftTemplate), req)
+}
+
 // GetStudentShifts mocks base method.
 func (m *MockRequestValidation) GetStudentShifts(req *lesson.GetStudentShiftsRequest) error {
 	m.ctrl.T.Helper()
@@ -312,6 +326,20 @@ func (m *MockRequestValidation) UpdateShiftSummarySchedule(req *lesson.UpdateShi
 func (mr *MockRequestValidationMockRecorder) UpdateShiftSummarySchedule(req interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateShiftSummarySchedule", reflect.TypeOf((*MockRequestValidation)(nil).UpdateShiftSummarySchedule), req)
+}
+
+// UpsertStudentShiftTemplate mocks base method.
+func (m *MockRequestValidation) UpsertStudentShiftTemplate(req *lesson.UpsertStudentShiftTemplateRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpsertStudentShiftTemplate", req)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpsertStudentShiftTemplate indicates an expected call of UpsertStudentShiftTemplate.
+func (mr *MockRequestValidationMockRecorder) UpsertStudentShiftTemplate(req interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertStudentShiftTemplate", reflect.TypeOf((*MockRequestValidation)(nil).UpsertStudentShiftTemplate), req)
 }
 
 // UpsertStudentShifts mocks base method.

--- a/api/mock/proto/lesson/service_grpc.pb.go.go
+++ b/api/mock/proto/lesson/service_grpc.pb.go.go
@@ -136,6 +136,26 @@ func (mr *MockLessonServiceClientMockRecorder) GetShiftSummary(ctx, in interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShiftSummary", reflect.TypeOf((*MockLessonServiceClient)(nil).GetShiftSummary), varargs...)
 }
 
+// GetStudentShiftTemplate mocks base method.
+func (m *MockLessonServiceClient) GetStudentShiftTemplate(ctx context.Context, in *lesson.GetStudentShiftTemplateRequest, opts ...grpc.CallOption) (*lesson.GetStudentShiftTemplateResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetStudentShiftTemplate", varargs...)
+	ret0, _ := ret[0].(*lesson.GetStudentShiftTemplateResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStudentShiftTemplate indicates an expected call of GetStudentShiftTemplate.
+func (mr *MockLessonServiceClientMockRecorder) GetStudentShiftTemplate(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStudentShiftTemplate", reflect.TypeOf((*MockLessonServiceClient)(nil).GetStudentShiftTemplate), varargs...)
+}
+
 // GetStudentShifts mocks base method.
 func (m *MockLessonServiceClient) GetStudentShifts(ctx context.Context, in *lesson.GetStudentShiftsRequest, opts ...grpc.CallOption) (*lesson.GetStudentShiftsResponse, error) {
 	m.ctrl.T.Helper()
@@ -436,6 +456,26 @@ func (mr *MockLessonServiceClientMockRecorder) UpdateShiftSummarySchedule(ctx, i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateShiftSummarySchedule", reflect.TypeOf((*MockLessonServiceClient)(nil).UpdateShiftSummarySchedule), varargs...)
 }
 
+// UpsertStudentShiftTemplate mocks base method.
+func (m *MockLessonServiceClient) UpsertStudentShiftTemplate(ctx context.Context, in *lesson.UpsertStudentShiftTemplateRequest, opts ...grpc.CallOption) (*lesson.UpsertStudentShiftTemplateResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpsertStudentShiftTemplate", varargs...)
+	ret0, _ := ret[0].(*lesson.UpsertStudentShiftTemplateResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpsertStudentShiftTemplate indicates an expected call of UpsertStudentShiftTemplate.
+func (mr *MockLessonServiceClientMockRecorder) UpsertStudentShiftTemplate(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertStudentShiftTemplate", reflect.TypeOf((*MockLessonServiceClient)(nil).UpsertStudentShiftTemplate), varargs...)
+}
+
 // UpsertStudentShifts mocks base method.
 func (m *MockLessonServiceClient) UpsertStudentShifts(ctx context.Context, in *lesson.UpsertStudentShiftsRequest, opts ...grpc.CallOption) (*lesson.UpsertStudentShiftsResponse, error) {
 	m.ctrl.T.Helper()
@@ -572,6 +612,21 @@ func (m *MockLessonServiceServer) GetShiftSummary(arg0 context.Context, arg1 *le
 func (mr *MockLessonServiceServerMockRecorder) GetShiftSummary(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShiftSummary", reflect.TypeOf((*MockLessonServiceServer)(nil).GetShiftSummary), arg0, arg1)
+}
+
+// GetStudentShiftTemplate mocks base method.
+func (m *MockLessonServiceServer) GetStudentShiftTemplate(arg0 context.Context, arg1 *lesson.GetStudentShiftTemplateRequest) (*lesson.GetStudentShiftTemplateResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetStudentShiftTemplate", arg0, arg1)
+	ret0, _ := ret[0].(*lesson.GetStudentShiftTemplateResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStudentShiftTemplate indicates an expected call of GetStudentShiftTemplate.
+func (mr *MockLessonServiceServerMockRecorder) GetStudentShiftTemplate(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStudentShiftTemplate", reflect.TypeOf((*MockLessonServiceServer)(nil).GetStudentShiftTemplate), arg0, arg1)
 }
 
 // GetStudentShifts mocks base method.
@@ -797,6 +852,21 @@ func (m *MockLessonServiceServer) UpdateShiftSummarySchedule(arg0 context.Contex
 func (mr *MockLessonServiceServerMockRecorder) UpdateShiftSummarySchedule(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateShiftSummarySchedule", reflect.TypeOf((*MockLessonServiceServer)(nil).UpdateShiftSummarySchedule), arg0, arg1)
+}
+
+// UpsertStudentShiftTemplate mocks base method.
+func (m *MockLessonServiceServer) UpsertStudentShiftTemplate(arg0 context.Context, arg1 *lesson.UpsertStudentShiftTemplateRequest) (*lesson.UpsertStudentShiftTemplateResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpsertStudentShiftTemplate", arg0, arg1)
+	ret0, _ := ret[0].(*lesson.UpsertStudentShiftTemplateResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpsertStudentShiftTemplate indicates an expected call of UpsertStudentShiftTemplate.
+func (mr *MockLessonServiceServerMockRecorder) UpsertStudentShiftTemplate(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertStudentShiftTemplate", reflect.TypeOf((*MockLessonServiceServer)(nil).UpsertStudentShiftTemplate), arg0, arg1)
 }
 
 // UpsertStudentShifts mocks base method.

--- a/api/proto/lesson/service.proto
+++ b/api/proto/lesson/service.proto
@@ -38,6 +38,8 @@ service LessonService {
   rpc ListStudentShifts(ListStudentShiftsRequest) returns (ListStudentShiftsResponse);
   rpc GetStudentShifts(GetStudentShiftsRequest) returns (GetStudentShiftsResponse);
   rpc UpsertStudentShifts(UpsertStudentShiftsRequest) returns (UpsertStudentShiftsResponse);
+  rpc GetStudentShiftTemplate(GetStudentShiftTemplateRequest) returns (GetStudentShiftTemplateResponse);
+  rpc UpsertStudentShiftTemplate(UpsertStudentShiftTemplateRequest) returns (UpsertStudentShiftTemplateResponse);
 }
 
 message ListLessonsRequest {
@@ -253,22 +255,50 @@ message GetStudentShiftsResponse {
   repeated StudentShift shifts     = 2;
 }
 
+message StudentSuggestedLesson {
+  int64 subject_id = 1 [(validate.rules).int64 = { gt: 0 }];
+  int64 total      = 2 [(validate.rules).int64 = { gte: 0 }];
+}
+
 message UpsertStudentShiftsRequest {
   string                          student_id        = 1 [(validate.rules).string = { min_len: 1 }];
   int64                           shift_summary_id  = 2 [(validate.rules).int64 = { gt: 0 }];
   repeated int64                  shift_ids         = 3 [(validate.rules).repeated = { unique: true, items: { int64: { gt: 0 }}}];
   bool                            decided           = 4;
   // int64                           suggested_classes = 5 [(validate.rules).int64 = { gte: 0 }];
-  repeated StudentSuggestedLesson lessons = 6 [(validate.rules).repeated = { items: { message: { required: true }}}];
+  repeated StudentSuggestedLesson lessons           = 6;
   reserved 5;
-}
-
-message StudentSuggestedLesson {
-  int64 subject_id = 1 [(validate.rules).int64 = { gt: 0 }];
-  int64 total      = 2 [(validate.rules).int64 = { gte: 0 }];
 }
 
 message UpsertStudentShiftsResponse {
   StudentSubmission     submission = 1;
   repeated StudentShift shifts     = 2;
 }
+
+message GetStudentShiftTemplateRequest {
+  string student_id = 1 [(validate.rules).string = { min_len: 1 }];
+}
+
+message GetStudentShiftTemplateResponse {
+  StudentShiftTemplate template = 1;
+}
+
+message StudentShiftTemplateToUpsert {
+  message Lesson {
+    string start_time = 1 [(validate.rules).string = { len: 4, pattern: "^[0-9]*$" }];
+    string end_time   = 2 [(validate.rules).string = { len: 4, pattern: "^[0-9]*$" }];
+  }
+  message Schedule {
+    int32           weekday = 1 [(validate.rules).int32 = { gte: 0, lte: 6 }];
+    repeated Lesson lessons = 2;
+  }
+  repeated Schedule               schedules         = 1 [(validate.rules).repeated = { max_items: 7 }];
+  repeated StudentSuggestedLesson suggested_lessons = 2;
+}
+
+message UpsertStudentShiftTemplateRequest {
+  string                       student_id = 1 [(validate.rules).string = { min_len: 1 }];
+  StudentShiftTemplateToUpsert template   = 2 [(validate.rules).message = { required: true }];
+}
+
+message UpsertStudentShiftTemplateResponse {}

--- a/api/proto/lesson/student_shift.proto
+++ b/api/proto/lesson/student_shift.proto
@@ -4,10 +4,30 @@ package lesson;
 
 option go_package = "github.com/calmato/shs-web/api/proto/lesson";
 
+import "lesson/student_submission.proto";
+
 message StudentShift {
   string student_id       = 1;
   int64  shift_id         = 2;
   int64  shift_summary_id = 3;
   int64  created_at       = 4;
   int64  updated_at       = 5;
+}
+
+message StudentShiftTemplate {
+  string                   student_id       = 1; // 生徒ID
+  repeated ShiftSchedule   schedules        = 2; // 希望授業時間一覧
+  repeated SuggestedLesson suggeste_lessons = 3; // 希望授業科目一覧
+  int64                    created_at       = 4; // 登録日時
+  int64                    updated_at       = 5; // 講師日時
+}
+
+message ShiftSchedule {
+  int32                   weekday = 1; // 曜日
+  repeated LessonSchedule lessons = 2; // 希望授業時間一覧
+}
+
+message LessonSchedule {
+  string start_time = 1; // 授業開始時間
+  string end_time   = 2; // 授業終了時間
 }

--- a/api/proto/lesson/student_submission.proto
+++ b/api/proto/lesson/student_submission.proto
@@ -11,7 +11,7 @@ message StudentSubmission {
   // int64                    suggested_classes = 4;
   int64                    created_at        = 5;
   int64                    updated_at        = 6;
-  repeated SuggestedLesson suggestedLessons  = 7;
+  repeated SuggestedLesson suggested_lessons = 7;
   reserved 4;
 }
 

--- a/infra/mysql/schema/2022020201-lessons-create-table-student-shift-templates.sql
+++ b/infra/mysql/schema/2022020201-lessons-create-table-student-shift-templates.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `lessons`.`student_shift_templates` (
+  `student_id`        VARCHAR(22) NOT NULL, -- 生徒ID
+  `schedules`         JSON        NOT NULL, -- 希望授業日時テンプレート
+  `suggested_lessons` JSON        NOT NULL, -- 希望授業科目テンプレート
+  `created_at`        DATETIME    NOT NULL, -- 登録日時
+  `updated_at`        DATETIME    NOT NULL, -- 更新日時
+  PRIMARY KEY(`student_id`)
+) ENGINE = InnoDB;


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
生徒の希望授業テンプレート管理用のAPIを実装しました
(Classroom Service側に寄せても良いかもと迷ったんだけど、Lesson関連との関係性のほうが強そうなのでLesson Serviceへ寄せました)

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
