### PR TITLE
fix(web/teacher): fix lesson list layout

### DIFF
--- a/web/teacher/src/components/organisms/TheShiftLessonCard.vue
+++ b/web/teacher/src/components/organisms/TheShiftLessonCard.vue
@@ -1,11 +1,11 @@
 <template>
   <v-card-text class="d-flex flex-column align-stretch">
-    <h2>
-      <v-chip v-if="detail" :color="getSubjectColor(detail)">
+    <h4 class="d-flex align-center justify-center">
+      <v-chip v-if="detail" :color="getSubjectColor(detail)" small class="mr-4">
         {{ getSubjectName(detail) }}
       </v-chip>
       <span>{{ getTime(summary.startTime) }} ~ {{ getTime(summary.endTime) }}</span>
-    </h2>
+    </h4>
     <div class="d-flex align-center justify-center mt-2">
       <a v-if="detail" class="d-block" @click="onClickEdit">
         <div class="black--text text-decoration-underline">生徒: {{ getStudentName(detail) }}</div>


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
シフト登録ページのレイアウトについて、ノートPCサイズの画面で見ると改行の位置が微妙な感じになっているため、レイアウトの微修正をしました。

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->

<img width="1440" alt="スクリーンショット 2022-02-10 20 41 50" src="https://user-images.githubusercontent.com/27718413/153402406-dd561770-b908-464e-b0a1-1ffb87e93e99.png">