### PR TITLE
fix(lesson-api): fix notify lesson decided

### DIFF
--- a/api/internal/lesson/api/shift.go
+++ b/api/internal/lesson/api/shift.go
@@ -130,6 +130,9 @@ func (s *lessonService) UpdateShiftSummaryDecided(
 	s.waitGroup.Add(1)
 	go func() {
 		defer s.waitGroup.Done()
+		if !req.Decided {
+			return
+		}
 		bgctx := context.Background()
 		in := &messenger.NotifyLessonDecidedRequest{ShiftSummaryId: req.Id}
 		if _, err := s.messenger.NotifyLessonDecided(bgctx, in); err != nil {

--- a/api/internal/lesson/api/shift_test.go
+++ b/api/internal/lesson/api/shift_test.go
@@ -305,7 +305,7 @@ func TestUpdateShiftSummaryDecided(t *testing.T) {
 		expect *testResponse
 	}{
 		{
-			name: "success",
+			name: "success when lesson decided",
 			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
 				in := &messenger.NotifyLessonDecidedRequest{ShiftSummaryId: 1}
 				out := &messenger.NotifyLessonDecidedResponse{}
@@ -314,6 +314,22 @@ func TestUpdateShiftSummaryDecided(t *testing.T) {
 				mocks.messenger.EXPECT().NotifyLessonDecided(gomock.Any(), in).Return(out, nil)
 			},
 			req: req,
+			expect: &testResponse{
+				code: codes.OK,
+				body: &lesson.UpdateShiftSummaryDecidedResponse{},
+			},
+		},
+		{
+			name: "success when lesson undecided",
+			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
+				req := &lesson.UpdateShiftSummaryDecidedRequest{Id: 1, Decided: false}
+				mocks.validator.EXPECT().UpdateShiftSummaryDecided(req).Return(nil)
+				mocks.db.ShiftSummary.EXPECT().UpdateDecided(ctx, int64(1), false).Return(nil)
+			},
+			req: &lesson.UpdateShiftSummaryDecidedRequest{
+				Id:      1,
+				Decided: false,
+			},
 			expect: &testResponse{
 				code: codes.OK,
 				body: &lesson.UpdateShiftSummaryDecidedResponse{},


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
現状だと、シフト作成画面で `授業を修正する` のボタンを押してもメール通知が飛んでしまっていました。
そのため、 `授業を確定する` のボタンを押したときのみメール通知が飛ぶように修正しました。

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
