### PR TITLE
fix(gateway): lessons sort by start at

### DIFF
--- a/api/internal/gateway/student/v1/entity/lesson.go
+++ b/api/internal/gateway/student/v1/entity/lesson.go
@@ -2,6 +2,7 @@ package entity
 
 import (
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/calmato/shs-web/api/internal/gateway/entity"
@@ -63,4 +64,10 @@ func NewLessons(lessons entity.Lessons, shifts map[int64]*entity.Shift) (Lessons
 		ls[i] = l
 	}
 	return ls, nil
+}
+
+func (ls Lessons) SortByStartAt() {
+	sort.SliceStable(ls, func(i, j int) bool {
+		return ls[i].StartAt.Before(ls[j].StartAt)
+	})
 }

--- a/api/internal/gateway/student/v1/entity/lesson_test.go
+++ b/api/internal/gateway/student/v1/entity/lesson_test.go
@@ -326,3 +326,108 @@ func TestLessons(t *testing.T) {
 		})
 	}
 }
+
+func TestLessons_SortByStartAt(t *testing.T) {
+	t.Parallel()
+	now := jst.Date(2022, 1, 15, 12, 30, 0, 0)
+	tests := []struct {
+		name    string
+		lessons Lessons
+		expect  Lessons
+	}{
+		{
+			name: "success",
+			lessons: Lessons{
+				{
+					ID:        1,
+					ShiftID:   1,
+					SubjectID: 1,
+					Room:      1,
+					TeacherID: "teacherid",
+					StudentID: "studentid",
+					Notes:     "感想",
+					StartAt:   jst.Date(2022, 2, 2, 17, 0, 0, 0),
+					EndAt:     jst.Date(2022, 2, 2, 18, 30, 0, 0),
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+				{
+					ID:        3,
+					ShiftID:   3,
+					SubjectID: 1,
+					Room:      1,
+					TeacherID: "teacherid",
+					StudentID: "studentid",
+					Notes:     "感想",
+					StartAt:   jst.Date(2022, 2, 2, 20, 0, 0, 0),
+					EndAt:     jst.Date(2022, 2, 2, 21, 30, 0, 0),
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+				{
+					ID:        2,
+					ShiftID:   2,
+					SubjectID: 1,
+					Room:      1,
+					TeacherID: "teacherid",
+					StudentID: "studentid",
+					Notes:     "感想",
+					StartAt:   jst.Date(2022, 2, 2, 18, 30, 0, 0),
+					EndAt:     jst.Date(2022, 2, 2, 20, 0, 0, 0),
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+			},
+			expect: Lessons{
+				{
+					ID:        1,
+					ShiftID:   1,
+					SubjectID: 1,
+					Room:      1,
+					TeacherID: "teacherid",
+					StudentID: "studentid",
+					Notes:     "感想",
+					StartAt:   jst.Date(2022, 2, 2, 17, 0, 0, 0),
+					EndAt:     jst.Date(2022, 2, 2, 18, 30, 0, 0),
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+				{
+					ID:        2,
+					ShiftID:   2,
+					SubjectID: 1,
+					Room:      1,
+					TeacherID: "teacherid",
+					StudentID: "studentid",
+					Notes:     "感想",
+					StartAt:   jst.Date(2022, 2, 2, 18, 30, 0, 0),
+					EndAt:     jst.Date(2022, 2, 2, 20, 0, 0, 0),
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+				{
+					ID:        3,
+					ShiftID:   3,
+					SubjectID: 1,
+					Room:      1,
+					TeacherID: "teacherid",
+					StudentID: "studentid",
+					Notes:     "感想",
+					StartAt:   jst.Date(2022, 2, 2, 20, 0, 0, 0),
+					EndAt:     jst.Date(2022, 2, 2, 21, 30, 0, 0),
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tt.lessons.SortByStartAt()
+			assert.Equal(t, tt.expect, tt.lessons)
+		})
+	}
+}

--- a/api/internal/gateway/teacher/v1/entity/lesson.go
+++ b/api/internal/gateway/teacher/v1/entity/lesson.go
@@ -2,6 +2,7 @@ package entity
 
 import (
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/calmato/shs-web/api/internal/gateway/entity"
@@ -62,5 +63,12 @@ func NewLessons(lessons entity.Lessons, shifts map[int64]*entity.Shift) (Lessons
 		}
 		ls[i] = l
 	}
+	ls.SortByStartAt()
 	return ls, nil
+}
+
+func (ls Lessons) SortByStartAt() {
+	sort.SliceStable(ls, func(i, j int) bool {
+		return ls[i].StartAt.Before(ls[j].StartAt)
+	})
 }

--- a/api/internal/gateway/teacher/v1/entity/lesson_test.go
+++ b/api/internal/gateway/teacher/v1/entity/lesson_test.go
@@ -326,3 +326,108 @@ func TestLessons(t *testing.T) {
 		})
 	}
 }
+
+func TestLessons_SortByStartAt(t *testing.T) {
+	t.Parallel()
+	now := jst.Date(2022, 1, 15, 12, 30, 0, 0)
+	tests := []struct {
+		name    string
+		lessons Lessons
+		expect  Lessons
+	}{
+		{
+			name: "success",
+			lessons: Lessons{
+				{
+					ID:        1,
+					ShiftID:   1,
+					SubjectID: 1,
+					Room:      1,
+					TeacherID: "teacherid",
+					StudentID: "studentid",
+					Notes:     "感想",
+					StartAt:   jst.Date(2022, 2, 2, 17, 0, 0, 0),
+					EndAt:     jst.Date(2022, 2, 2, 18, 30, 0, 0),
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+				{
+					ID:        3,
+					ShiftID:   3,
+					SubjectID: 1,
+					Room:      1,
+					TeacherID: "teacherid",
+					StudentID: "studentid",
+					Notes:     "感想",
+					StartAt:   jst.Date(2022, 2, 2, 20, 0, 0, 0),
+					EndAt:     jst.Date(2022, 2, 2, 21, 30, 0, 0),
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+				{
+					ID:        2,
+					ShiftID:   2,
+					SubjectID: 1,
+					Room:      1,
+					TeacherID: "teacherid",
+					StudentID: "studentid",
+					Notes:     "感想",
+					StartAt:   jst.Date(2022, 2, 2, 18, 30, 0, 0),
+					EndAt:     jst.Date(2022, 2, 2, 20, 0, 0, 0),
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+			},
+			expect: Lessons{
+				{
+					ID:        1,
+					ShiftID:   1,
+					SubjectID: 1,
+					Room:      1,
+					TeacherID: "teacherid",
+					StudentID: "studentid",
+					Notes:     "感想",
+					StartAt:   jst.Date(2022, 2, 2, 17, 0, 0, 0),
+					EndAt:     jst.Date(2022, 2, 2, 18, 30, 0, 0),
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+				{
+					ID:        2,
+					ShiftID:   2,
+					SubjectID: 1,
+					Room:      1,
+					TeacherID: "teacherid",
+					StudentID: "studentid",
+					Notes:     "感想",
+					StartAt:   jst.Date(2022, 2, 2, 18, 30, 0, 0),
+					EndAt:     jst.Date(2022, 2, 2, 20, 0, 0, 0),
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+				{
+					ID:        3,
+					ShiftID:   3,
+					SubjectID: 1,
+					Room:      1,
+					TeacherID: "teacherid",
+					StudentID: "studentid",
+					Notes:     "感想",
+					StartAt:   jst.Date(2022, 2, 2, 20, 0, 0, 0),
+					EndAt:     jst.Date(2022, 2, 2, 21, 30, 0, 0),
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tt.lessons.SortByStartAt()
+			assert.Equal(t, tt.expect, tt.lessons)
+		})
+	}
+}


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
授業一覧ダイアログでの表示について、授業日時順で並んでほしいところがバラバラな順番で表示されてしまっていました。
そのため、レスポンスを授業開始日時順でソートできるよう修正しました。。

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
