### PR TITLE
fix(messenger-api): fix health check timeout

### DIFF
--- a/api/internal/messenger/cmd/notifier/exec.go
+++ b/api/internal/messenger/cmd/notifier/exec.go
@@ -125,7 +125,7 @@ func Exec() error {
 		return
 	})
 	eg.Go(func() (err error) {
-		err = n.Run(ectx, msgCh, int(conf.Concurrency), int(conf.MailboxCapacity))
+		err = n.Run(ectx, msgCh, int(conf.Concurrency))
 		if err != nil {
 			logger.Error("Failed to run notifier", zap.Error(err))
 		}

--- a/api/internal/messenger/notifier/notifier.go
+++ b/api/internal/messenger/notifier/notifier.go
@@ -21,14 +21,12 @@ type Params struct {
 	TeacherWebURL *url.URL
 	StudentWebURL *url.URL
 	Mailer        mailer.Client
-	Puller        pubsub.Puller
 	UserService   user.UserServiceClient
 }
 
 type Notifier struct {
 	logger        *zap.Logger
 	mailer        mailer.Client
-	puller        pubsub.Puller
 	user          user.UserServiceClient
 	teacherWebURL func() *url.URL
 	studentWebURL func() *url.URL
@@ -38,7 +36,6 @@ func NewNotifier(params *Params) *Notifier {
 	return &Notifier{
 		logger: params.Logger,
 		mailer: params.Mailer,
-		puller: params.Puller,
 		user:   params.UserService,
 		teacherWebURL: func() *url.URL {
 			url := *params.TeacherWebURL // copy
@@ -51,9 +48,7 @@ func NewNotifier(params *Params) *Notifier {
 	}
 }
 
-func (n *Notifier) Run(
-	ctx context.Context, msgCh <-chan *pubsub.Message, concurrency int, mailboxCapacity int,
-) error {
+func (n *Notifier) Run(ctx context.Context, msgCh <-chan *pubsub.Message, concurrency int) error {
 	eg, ectx := errgroup.WithContext(ctx)
 	// 指定された並列実行数分goroutineを実行
 	for i := 0; i < concurrency; i++ {

--- a/api/internal/messenger/notifier/notifier_test.go
+++ b/api/internal/messenger/notifier/notifier_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net/url"
-	"os"
 	"testing"
 	"time"
 
@@ -51,7 +50,6 @@ func newNotifier(mocks *mocks, opts ...testOption) *Notifier {
 	return &Notifier{
 		logger: zap.NewNop(),
 		mailer: mocks.mailer,
-		puller: mocks.puller,
 		user:   mocks.user,
 		teacherWebURL: func() *url.URL {
 			url := *webURL
@@ -84,7 +82,7 @@ func TestNotifier_Run(t *testing.T) {
 	notifier := newNotifier(mocks)
 	msgCh := make(chan *pubsub.Message, 1)
 	go func() {
-		assert.NoError(t, notifier.Run(ctx, msgCh, 1, 1))
+		assert.NoError(t, notifier.Run(ctx, msgCh, 1))
 	}()
 	time.Sleep(3 * time.Second)
 	cancel()
@@ -211,11 +209,5 @@ func TestNotifier_Dispatch(t *testing.T) {
 			assert.Equal(t, tt.isErr, err != nil, err)
 			assert.Equal(t, tt.expect, actual)
 		})
-	}
-}
-
-func setEnv() {
-	if os.Getenv("PUBSUB_EMULATOR_HOST") == "" {
-		os.Setenv("PUBSUB_EMULATOR_HOST", "127.0.0.1:8085")
 	}
 }

--- a/api/pkg/pubsub/puller_test.go
+++ b/api/pkg/pubsub/puller_test.go
@@ -50,9 +50,14 @@ func TestPuller(t *testing.T) {
 
 	opts := []PullerOption{
 		WithPullerTimeout(time.Second * 2),
-		WithPullerMaxRetries(2),
 		WithPullerConcurrency(2),
 		WithPullerLogger(zap.NewNop()),
+		WithPullerMaxRetries(2),
+		WithPullerMaxExtension(20 * time.Second),
+		WithPullerMaxExtensionPeriod(0),
+		WithPullerMaxOutstandingMessages(3),
+		WithPullerMaxOutstandingBytes(512),
+		WithPullerSync(true),
 	}
 	puller := NewPuller(client, testTopic, opts...)
 	assert.NotNil(t, puller)

--- a/infra/kubernetes/stg/default/messenger-notifier.deployment.yaml.temp
+++ b/infra/kubernetes/stg/default/messenger-notifier.deployment.yaml.temp
@@ -27,15 +27,7 @@ spec:
         ports:
         - name: default
           containerPort: 8080
-        livenessProbe:
-          tcpSocket:
-            port: 8080
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          failureThreshold: 3
         env:
-        - name: PORT
-          value: '8080'
         - name: METRICS_PORT
           value: '9090'
         - name: LOG_LEVEL


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
一定時間したらPodが停止処理に入ってしまう不具合について、不要なヘルスチェックが設定されていたためであったため修正しました。(ついでにテストカバレッジの向上, 不要なコードの削除周りもしました)

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
