### PR TITLE
feat(gateway): add field to list shifts response

### DIFF
--- a/api/internal/gateway/entity/teacher_submission.go
+++ b/api/internal/gateway/entity/teacher_submission.go
@@ -29,3 +29,11 @@ func (ss TeacherSubmissions) MapByShiftSummaryID() map[int64]*TeacherSubmission 
 	}
 	return res
 }
+
+func (ss TeacherSubmissions) MapByTeacherID() map[string]*TeacherSubmission {
+	res := make(map[string]*TeacherSubmission, len(ss))
+	for _, s := range ss {
+		res[s.TeacherId] = s
+	}
+	return res
+}

--- a/api/internal/gateway/entity/teacher_submission_test.go
+++ b/api/internal/gateway/entity/teacher_submission_test.go
@@ -149,3 +149,65 @@ func TestTeacherSubmissions_MapByShiftSummaryID(t *testing.T) {
 		})
 	}
 }
+
+func TestTeacherSubmissions_MapByTeacherID(t *testing.T) {
+	t.Parallel()
+	now := jst.Now()
+	tests := []struct {
+		name        string
+		submissions TeacherSubmissions
+		expect      map[string]*TeacherSubmission
+	}{
+		{
+			name: "success",
+			submissions: TeacherSubmissions{
+				{
+					TeacherSubmission: &lesson.TeacherSubmission{
+						TeacherId:      "teacherid1",
+						ShiftSummaryId: 1,
+						Decided:        true,
+						CreatedAt:      now.Unix(),
+						UpdatedAt:      now.Unix(),
+					},
+				},
+				{
+					TeacherSubmission: &lesson.TeacherSubmission{
+						TeacherId:      "teacherid2",
+						ShiftSummaryId: 1,
+						Decided:        true,
+						CreatedAt:      now.Unix(),
+						UpdatedAt:      now.Unix(),
+					},
+				},
+			},
+			expect: map[string]*TeacherSubmission{
+				"teacherid1": {
+					TeacherSubmission: &lesson.TeacherSubmission{
+						TeacherId:      "teacherid1",
+						ShiftSummaryId: 1,
+						Decided:        true,
+						CreatedAt:      now.Unix(),
+						UpdatedAt:      now.Unix(),
+					},
+				},
+				"teacherid2": {
+					TeacherSubmission: &lesson.TeacherSubmission{
+						TeacherId:      "teacherid2",
+						ShiftSummaryId: 1,
+						Decided:        true,
+						CreatedAt:      now.Unix(),
+						UpdatedAt:      now.Unix(),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expect, tt.submissions.MapByTeacherID())
+		})
+	}
+}

--- a/api/internal/gateway/teacher/v1/entity/student_submission.go
+++ b/api/internal/gateway/teacher/v1/entity/student_submission.go
@@ -30,6 +30,7 @@ type StudentSuggestedLessons []*StudentSuggestedLesson
 
 type StudentSubmissionDetail struct {
 	Student               *Student                `json:"student"`               // 生徒情報
+	IsSubmit              bool                    `json:"isSubmit"`              // 授業希望提出フラグ
 	SuggestedLessons      StudentSuggestedLessons `json:"suggestedLessons"`      // 希望受講授業一覧
 	SuggestedLessonsTotal int64                   `json:"suggestedLessonsTotal"` // 希望受講授業数
 	LessonTotal           int64                   `json:"lessonTotal"`           // 登録受講授業数
@@ -64,7 +65,7 @@ func NewStudentSubmissions(
 ) StudentSubmissions {
 	ss := make(StudentSubmissions, len(summaries))
 	for i, s := range summaries {
-		submission := submissions[s.Id] // null: 出勤不可
+		submission := submissions[s.Id] // null: 受講不可
 		ss[i] = NewStudentSubmission(s, submission)
 	}
 	return ss
@@ -92,15 +93,18 @@ func NewStudentSubmissionDetail(
 	lessons entity.Lessons,
 ) *StudentSubmissionDetail {
 	var suggestedLessonsTotal int64
+	var isSubmit bool
 	suggestedLessons := StudentSuggestedLessons{}
 	if submission != nil {
 		for _, l := range submission.SuggestedLessons {
 			suggestedLessonsTotal += l.Total
 		}
 		suggestedLessons = NewStudentSuggestedLessons(submission.SuggestedLessons)
+		isSubmit = submission.Decided
 	}
 	return &StudentSubmissionDetail{
 		Student:               NewStudent(student, subjects),
+		IsSubmit:              isSubmit,
 		SuggestedLessons:      suggestedLessons,
 		SuggestedLessonsTotal: suggestedLessonsTotal,
 		LessonTotal:           int64(len(lessons)),

--- a/api/internal/gateway/teacher/v1/entity/student_submission_test.go
+++ b/api/internal/gateway/teacher/v1/entity/student_submission_test.go
@@ -292,6 +292,7 @@ func TestStudentSubmissionDetail(t *testing.T) {
 					CreatedAt: now,
 					UpdatedAt: now,
 				},
+				IsSubmit: true,
 				SuggestedLessons: StudentSuggestedLessons{
 					{SubjectID: 1, Total: 4},
 					{SubjectID: 2, Total: 4},
@@ -423,6 +424,7 @@ func TestStudentSubmissionDetails(t *testing.T) {
 						CreatedAt: now,
 						UpdatedAt: now,
 					},
+					IsSubmit: true,
 					SuggestedLessons: StudentSuggestedLessons{
 						{SubjectID: 1, Total: 4},
 						{SubjectID: 2, Total: 4},
@@ -444,6 +446,7 @@ func TestStudentSubmissionDetails(t *testing.T) {
 						CreatedAt:     now,
 						UpdatedAt:     now,
 					},
+					IsSubmit:              false,
 					SuggestedLessons:      StudentSuggestedLessons{},
 					SuggestedLessonsTotal: 0,
 					LessonTotal:           1,

--- a/api/internal/gateway/teacher/v1/entity/teacher_submission.go
+++ b/api/internal/gateway/teacher/v1/entity/teacher_submission.go
@@ -23,6 +23,7 @@ type TeacherSubmissions []*TeacherSubmission
 
 type TeacherSubmissionDetail struct {
 	Teacher     *Teacher `json:"teacher"`     // 講師情報
+	IsSubmit    bool     `json:"isSubmit"`    // シフト提出フラグ
 	LessonTotal int64    `json:"lessonTotal"` // 登録担当授業数
 }
 
@@ -62,21 +63,34 @@ func NewTeacherSubmissions(
 }
 
 func NewTeacherSubmissionDetail(
-	teacher *entity.Teacher, subjects entity.Subjects, lessons entity.Lessons,
+	teacher *entity.Teacher,
+	subjects entity.Subjects,
+	submission *entity.TeacherSubmission,
+	lessons entity.Lessons,
 ) *TeacherSubmissionDetail {
+	var isSubmit bool
+	if submission != nil {
+		isSubmit = submission.Decided
+	}
 	return &TeacherSubmissionDetail{
 		Teacher:     NewTeacher(teacher, subjects),
+		IsSubmit:    isSubmit,
 		LessonTotal: int64(len(lessons)),
 	}
 }
 
 func NewTeacherSubmissionDetails(
-	teachers entity.Teachers, subjects map[string]entity.Subjects, lessonsMap map[string]entity.Lessons,
+	teachers entity.Teachers,
+	subjectsMap map[string]entity.Subjects,
+	submissionMap map[string]*entity.TeacherSubmission,
+	lessonsMap map[string]entity.Lessons,
 ) TeacherSubmissionDetails {
 	ss := make(TeacherSubmissionDetails, len(teachers))
 	for i, teacher := range teachers {
+		subjects := subjectsMap[teacher.Id]
+		submission := submissionMap[teacher.Id]
 		lessons := lessonsMap[teacher.Id]
-		ss[i] = NewTeacherSubmissionDetail(teacher, subjects[teacher.Id], lessons)
+		ss[i] = NewTeacherSubmissionDetail(teacher, subjects, submission, lessons)
 	}
 	return ss
 }

--- a/api/internal/gateway/teacher/v1/entity/teacher_submission_test.go
+++ b/api/internal/gateway/teacher/v1/entity/teacher_submission_test.go
@@ -151,11 +151,12 @@ func TestTeacherSubmissionDetail(t *testing.T) {
 	t.Parallel()
 	now := jst.Date(2021, 8, 2, 18, 30, 0, 0)
 	tests := []struct {
-		name     string
-		teacher  *entity.Teacher
-		subjects entity.Subjects
-		lessons  entity.Lessons
-		expect   *TeacherSubmissionDetail
+		name       string
+		teacher    *entity.Teacher
+		subjects   entity.Subjects
+		submission *entity.TeacherSubmission
+		lessons    entity.Lessons
+		expect     *TeacherSubmissionDetail
 	}{
 		{
 			name: "success",
@@ -182,6 +183,15 @@ func TestTeacherSubmissionDetail(t *testing.T) {
 						CreatedAt:  now.Unix(),
 						UpdatedAt:  now.Unix(),
 					},
+				},
+			},
+			submission: &entity.TeacherSubmission{
+				TeacherSubmission: &lesson.TeacherSubmission{
+					TeacherId:      "teacherid",
+					ShiftSummaryId: 1,
+					Decided:        true,
+					CreatedAt:      now.Unix(),
+					UpdatedAt:      now.Unix(),
 				},
 			},
 			lessons: entity.Lessons{
@@ -226,6 +236,7 @@ func TestTeacherSubmissionDetail(t *testing.T) {
 						},
 					},
 				},
+				IsSubmit:    true,
 				LessonTotal: 1,
 			},
 		},
@@ -235,7 +246,7 @@ func TestTeacherSubmissionDetail(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.expect, NewTeacherSubmissionDetail(tt.teacher, tt.subjects, tt.lessons))
+			assert.Equal(t, tt.expect, NewTeacherSubmissionDetail(tt.teacher, tt.subjects, tt.submission, tt.lessons))
 		})
 	}
 }
@@ -244,11 +255,12 @@ func TestTeacherSubmissionDetails(t *testing.T) {
 	t.Parallel()
 	now := jst.Date(2021, 8, 2, 18, 30, 0, 0)
 	tests := []struct {
-		name     string
-		teachers entity.Teachers
-		subjects map[string]entity.Subjects
-		lessons  map[string]entity.Lessons
-		expect   TeacherSubmissionDetails
+		name        string
+		teachers    entity.Teachers
+		subjects    map[string]entity.Subjects
+		submissions map[string]*entity.TeacherSubmission
+		lessons     map[string]entity.Lessons
+		expect      TeacherSubmissionDetails
 	}{
 		{
 			name: "success",
@@ -291,6 +303,17 @@ func TestTeacherSubmissionDetails(t *testing.T) {
 							CreatedAt:  now.Unix(),
 							UpdatedAt:  now.Unix(),
 						},
+					},
+				},
+			},
+			submissions: map[string]*entity.TeacherSubmission{
+				"teacherid": {
+					TeacherSubmission: &lesson.TeacherSubmission{
+						TeacherId:      "teacherid",
+						ShiftSummaryId: 1,
+						Decided:        true,
+						CreatedAt:      now.Unix(),
+						UpdatedAt:      now.Unix(),
 					},
 				},
 			},
@@ -339,6 +362,7 @@ func TestTeacherSubmissionDetails(t *testing.T) {
 							},
 						},
 					},
+					IsSubmit:    false,
 					LessonTotal: 0,
 				},
 				{
@@ -358,6 +382,7 @@ func TestTeacherSubmissionDetails(t *testing.T) {
 							SchoolTypeHighSchool:       {},
 						},
 					},
+					IsSubmit:    true,
 					LessonTotal: 1,
 				},
 			},
@@ -368,7 +393,7 @@ func TestTeacherSubmissionDetails(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.expect, NewTeacherSubmissionDetails(tt.teachers, tt.subjects, tt.lessons))
+			assert.Equal(t, tt.expect, NewTeacherSubmissionDetails(tt.teachers, tt.subjects, tt.submissions, tt.lessons))
 		})
 	}
 }

--- a/api/internal/gateway/teacher/v1/handler/shift.go
+++ b/api/internal/gateway/teacher/v1/handler/shift.go
@@ -304,8 +304,13 @@ func (h *apiV1Handler) ListShifts(ctx *gin.Context) {
 		gshifts, err = h.listShiftsBySummaryID(ectx, shiftSummaryID)
 		return
 	})
+	var gteacherSubmissions gentity.TeacherSubmissions
+	eg.Go(func() error {
+		// TODO: lesson-apiの実装後、詳細実装
+		return nil
+	})
 	var gstudentSubmissions gentity.StudentSubmissions
-	eg.Go((func() error {
+	eg.Go(func() error {
 		in := &lesson.ListStudentSubmissionsByStudentIDsRequest{
 			StudentIds:     gstudents.IDs(),
 			ShiftSummaryId: shiftSummaryID,
@@ -316,7 +321,7 @@ func (h *apiV1Handler) ListShifts(ctx *gin.Context) {
 		}
 		gstudentSubmissions = gentity.NewStudentSubmissions(out.Submissions)
 		return nil
-	}))
+	})
 	var glessons gentity.Lessons
 	eg.Go(func() error {
 		in := &lesson.ListLessonsRequest{
@@ -346,13 +351,14 @@ func (h *apiV1Handler) ListShifts(ctx *gin.Context) {
 	}
 	teacherLessonsMap := glessons.GroupByTeacherID()
 	studentLessonsMap := glessons.GroupByStudentID()
+	teacherSubmissionMap := gteacherSubmissions.MapByTeacherID()
 	studentSubmissionMap := gstudentSubmissions.MapByStudentID()
 	summary := entity.NewShiftSummary(gsummary)
 	res := &response.ShiftsResponse{
 		Summary:  summary,
 		Shifts:   entity.NewShiftDetailsForMonth(summary, shiftsMap),
 		Rooms:    rooms,
-		Teachers: entity.NewTeacherSubmissionDetails(gteachers, gteacherSubjects, teacherLessonsMap),
+		Teachers: entity.NewTeacherSubmissionDetails(gteachers, gteacherSubjects, teacherSubmissionMap, teacherLessonsMap),
 		Students: entity.NewStudentSubmissionDetails(gstudents, gstudentSubjects, studentSubmissionMap, studentLessonsMap),
 		Lessons:  lessons,
 	}

--- a/api/internal/gateway/teacher/v1/handler/shift_test.go
+++ b/api/internal/gateway/teacher/v1/handler/shift_test.go
@@ -1091,6 +1091,7 @@ func TestListShifts(t *testing.T) {
 									},
 								},
 							},
+							IsSubmit:    false,
 							LessonTotal: 1,
 						},
 					},
@@ -1118,6 +1119,7 @@ func TestListShifts(t *testing.T) {
 									},
 								},
 							},
+							IsSubmit: true,
 							SuggestedLessons: entity.StudentSuggestedLessons{
 								{SubjectID: 1, Total: 4},
 								{SubjectID: 2, Total: 4},

--- a/docs/swagger/teacher/components/schemas/v1/shifts.response.yaml
+++ b/docs/swagger/teacher/components/schemas/v1/shifts.response.yaml
@@ -488,7 +488,6 @@ shiftLessonsResponse:
       createdAt: '2021-12-12T12:12:30.100Z'
       updatedAt: '2021-12-12T12:12:30.100Z'
     total: 1
-
 shiftsResponse:
   type: object
   properties:
@@ -684,6 +683,9 @@ shiftsResponse:
                         updatedAt:
                           type: string
                           description: 更新日時
+          isSubmit:
+            type: boolean
+            description: シフト提出フラグ
           lessonTotal:
             type: integer
             format: int64
@@ -757,6 +759,9 @@ shiftsResponse:
                     updatedAt:
                       type: string
                       description: 更新日時
+          isSubmit:
+            type: boolean
+            description: 授業希望提出フラグ
           suggestedLessons:
             type: array
             description: 受講希望授業一覧


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
クライアント実装も並行して進められるように、まずはAPIのレスポンスへシフト/授業希望提出フラグを追加しました。

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->
* [ ] クライアント実装
* [ ] Lesson API周りの実装
* [ ] Gateway周りの実装

## 備考

<!-- マージ後に必要な操作などがあればここに -->
* https://github.com/calmato/shs-web/issues/317
