### PR TITLE
feat(lesson-api): implement list teacher submissions by teacher ids

### DIFF
--- a/api/internal/lesson/api/teacher_shift.go
+++ b/api/internal/lesson/api/teacher_shift.go
@@ -31,6 +31,24 @@ func (s *lessonService) ListTeacherSubmissionsByShiftSummaryIDs(
 	return res, nil
 }
 
+func (s *lessonService) ListTeacherSubmissionsByTeacherIDs(
+	ctx context.Context, req *lesson.ListTeacherSubmissionsByTeacherIDsRequest,
+) (*lesson.ListTeacherSubmissionsByTeacherIDsResponse, error) {
+	if err := s.validator.ListTeacherSubmissionsByTeacherIDs(req); err != nil {
+		return nil, gRPCError(err)
+	}
+
+	submissions, err := s.db.TeacherSubmission.ListByTeacherIDs(ctx, req.TeacherIds, req.ShiftSummaryId)
+	if err != nil {
+		return nil, gRPCError(err)
+	}
+
+	res := &lesson.ListTeacherSubmissionsByTeacherIDsResponse{
+		Submissions: submissions.Proto(),
+	}
+	return res, nil
+}
+
 func (s *lessonService) ListTeacherShifts(
 	ctx context.Context, req *lesson.ListTeacherShiftsRequest,
 ) (*lesson.ListTeacherShiftsResponse, error) {

--- a/api/internal/lesson/database/database.go
+++ b/api/internal/lesson/database/database.go
@@ -84,6 +84,9 @@ type TeacherSubmission interface {
 	ListByShiftSummaryIDs(
 		ctx context.Context, teacherID string, summaryIDs []int64, fields ...string,
 	) (entity.TeacherSubmissions, error)
+	ListByTeacherIDs(
+		ctx context.Context, teacherIDs []string, summaryID int64, fields ...string,
+	) (entity.TeacherSubmissions, error)
 	Get(ctx context.Context, teacherID string, summaryID int64, fields ...string) (*entity.TeacherSubmission, error)
 }
 

--- a/api/internal/lesson/database/teacher_submission.go
+++ b/api/internal/lesson/database/teacher_submission.go
@@ -43,6 +43,22 @@ func (s *teacherSubmission) ListByShiftSummaryIDs(
 	return submissions, dbError(err)
 }
 
+func (s *teacherSubmission) ListByTeacherIDs(
+	ctx context.Context, teacherIDs []string, summaryID int64, fields ...string,
+) (entity.TeacherSubmissions, error) {
+	var submissions entity.TeacherSubmissions
+	if len(fields) == 0 {
+		fields = teacherSubmissionFields
+	}
+
+	stmt := s.db.DB.Table(teacherSubmissionTable).Select(fields).
+		Where("teacher_id IN (?)", teacherIDs).
+		Where("shift_summary_id = ?", summaryID)
+
+	err := stmt.Find(&submissions).Error
+	return submissions, dbError(err)
+}
+
 func (s *teacherSubmission) Get(
 	ctx context.Context, teacherID string, summaryID int64, fields ...string,
 ) (*entity.TeacherSubmission, error) {

--- a/api/internal/lesson/database/teacher_submission_test.go
+++ b/api/internal/lesson/database/teacher_submission_test.go
@@ -107,9 +107,8 @@ func TestTeacherSubmission_ListByTeacherIDs(t *testing.T) {
 
 	now := jst.Date(2021, 12, 10, 12, 0, 0, 0)
 
-	summaries := make(entity.ShiftSummaries, 3)
-	summaries[0] = testShiftSummary(1, 202202, jst.Date(2022, 1, 1, 0, 0, 0, 0), jst.Date(2022, 1, 15, 0, 0, 0, 0), now)
-	err = m.db.DB.Create(&summaries).Error
+	summary := testShiftSummary(1, 202202, jst.Date(2022, 1, 1, 0, 0, 0, 0), jst.Date(2022, 1, 15, 0, 0, 0, 0), now)
+	err = m.db.DB.Create(&summary).Error
 	require.NoError(t, err)
 
 	submissions := make(entity.TeacherSubmissions, 2)

--- a/api/internal/lesson/database/teacher_submission_test.go
+++ b/api/internal/lesson/database/teacher_submission_test.go
@@ -113,7 +113,7 @@ func TestTeacherSubmission_ListByTeacherIDs(t *testing.T) {
 
 	submissions := make(entity.TeacherSubmissions, 2)
 	submissions[0] = testTeacherSubmission("teacherid01", 1, true, now)
-	submissions[1] = testTeacherSubmission("teacherid02", 2, false, now)
+	submissions[1] = testTeacherSubmission("teacherid02", 1, false, now)
 	err = m.db.DB.Create(&submissions).Error
 	require.NoError(t, err)
 

--- a/api/internal/lesson/validation/teacher_shift.go
+++ b/api/internal/lesson/validation/teacher_shift.go
@@ -13,6 +13,17 @@ func (v *requestValidation) ListTeacherSubmissionsByShiftSummaryIDs(
 	return nil
 }
 
+func (v *requestValidation) ListTeacherSubmissionsByTeacherIDs(
+	req *lesson.ListTeacherSubmissionsByTeacherIDsRequest,
+) error {
+	if err := req.Validate(); err != nil {
+		validate := err.(lesson.ListTeacherSubmissionsByTeacherIDsRequestValidationError)
+		return validationError(validate.Error())
+	}
+
+	return nil
+}
+
 func (v *requestValidation) ListTeacherShifts(req *lesson.ListTeacherShiftsRequest) error {
 	if err := req.Validate(); err != nil {
 		validate := err.(lesson.ListTeacherShiftsRequestValidationError)

--- a/api/internal/lesson/validation/teacher_shift_test.go
+++ b/api/internal/lesson/validation/teacher_shift_test.go
@@ -60,6 +60,59 @@ func TestListTeacherSubmissionsByShiftSummaryIDs(t *testing.T) {
 	}
 }
 
+func TestListTeacherSubmissionsByTeacherIDs(t *testing.T) {
+	t.Parallel()
+	validator := NewRequestValidation()
+
+	tests := []struct {
+		name  string
+		req   *lesson.ListTeacherSubmissionsByTeacherIDsRequest
+		isErr bool
+	}{
+		{
+			name: "success",
+			req: &lesson.ListTeacherSubmissionsByTeacherIDsRequest{
+				TeacherIds:     []string{"teacherid"},
+				ShiftSummaryId: 1,
+			},
+			isErr: false,
+		},
+		{
+			name: "TeacherIds is unique",
+			req: &lesson.ListTeacherSubmissionsByTeacherIDsRequest{
+				TeacherIds:     []string{"teacherid", "teacherid"},
+				ShiftSummaryId: 1,
+			},
+			isErr: true,
+		},
+		{
+			name: "TeacherIds is items.min_len",
+			req: &lesson.ListTeacherSubmissionsByTeacherIDsRequest{
+				TeacherIds:     []string{""},
+				ShiftSummaryId: 1,
+			},
+			isErr: true,
+		},
+		{
+			name: "ShiftSummaryId is gt",
+			req: &lesson.ListTeacherSubmissionsByTeacherIDsRequest{
+				TeacherIds:     []string{"teacherid"},
+				ShiftSummaryId: 0,
+			},
+			isErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validator.ListTeacherSubmissionsByTeacherIDs(tt.req)
+			assert.Equal(t, tt.isErr, err != nil, err)
+		})
+	}
+}
+
 func TestListTeacherShifts(t *testing.T) {
 	t.Parallel()
 	validator := NewRequestValidation()

--- a/api/internal/lesson/validation/validator.go
+++ b/api/internal/lesson/validation/validator.go
@@ -26,6 +26,7 @@ type RequestValidation interface {
 	CreateShifts(req *lesson.CreateShiftsRequest) error
 	ListSubmissions(req *lesson.ListSubmissionsRequest) error
 	ListTeacherSubmissionsByShiftSummaryIDs(req *lesson.ListTeacherSubmissionsByShiftSummaryIDsRequest) error
+	ListTeacherSubmissionsByTeacherIDs(req *lesson.ListTeacherSubmissionsByTeacherIDsRequest) error
 	ListTeacherShifts(req *lesson.ListTeacherShiftsRequest) error
 	GetTeacherShifts(req *lesson.GetTeacherShiftsRequest) error
 	UpsertTeacherShifts(req *lesson.UpsertTeacherShiftsRequest) error

--- a/api/mock/lesson/database/database.go
+++ b/api/mock/lesson/database/database.go
@@ -434,6 +434,26 @@ func (mr *MockTeacherSubmissionMockRecorder) ListByShiftSummaryIDs(ctx, teacherI
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByShiftSummaryIDs", reflect.TypeOf((*MockTeacherSubmission)(nil).ListByShiftSummaryIDs), varargs...)
 }
 
+// ListByTeacherIDs mocks base method.
+func (m *MockTeacherSubmission) ListByTeacherIDs(ctx context.Context, teacherIDs []string, summaryID int64, fields ...string) (entity.TeacherSubmissions, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, teacherIDs, summaryID}
+	for _, a := range fields {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListByTeacherIDs", varargs...)
+	ret0, _ := ret[0].(entity.TeacherSubmissions)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListByTeacherIDs indicates an expected call of ListByTeacherIDs.
+func (mr *MockTeacherSubmissionMockRecorder) ListByTeacherIDs(ctx, teacherIDs, summaryID interface{}, fields ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, teacherIDs, summaryID}, fields...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByTeacherIDs", reflect.TypeOf((*MockTeacherSubmission)(nil).ListByTeacherIDs), varargs...)
+}
+
 // MockTeacherShift is a mock of TeacherShift interface.
 type MockTeacherShift struct {
 	ctrl     *gomock.Controller

--- a/api/mock/lesson/validation/validator.go
+++ b/api/mock/lesson/validation/validator.go
@@ -286,6 +286,20 @@ func (mr *MockRequestValidationMockRecorder) ListTeacherSubmissionsByShiftSummar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTeacherSubmissionsByShiftSummaryIDs", reflect.TypeOf((*MockRequestValidation)(nil).ListTeacherSubmissionsByShiftSummaryIDs), req)
 }
 
+// ListTeacherSubmissionsByTeacherIDs mocks base method.
+func (m *MockRequestValidation) ListTeacherSubmissionsByTeacherIDs(req *lesson.ListTeacherSubmissionsByTeacherIDsRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListTeacherSubmissionsByTeacherIDs", req)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ListTeacherSubmissionsByTeacherIDs indicates an expected call of ListTeacherSubmissionsByTeacherIDs.
+func (mr *MockRequestValidationMockRecorder) ListTeacherSubmissionsByTeacherIDs(req interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTeacherSubmissionsByTeacherIDs", reflect.TypeOf((*MockRequestValidation)(nil).ListTeacherSubmissionsByTeacherIDs), req)
+}
+
 // UpdateLesson mocks base method.
 func (m *MockRequestValidation) UpdateLesson(req *lesson.UpdateLessonRequest) error {
 	m.ctrl.T.Helper()

--- a/api/mock/proto/lesson/service_grpc.pb.go.go
+++ b/api/mock/proto/lesson/service_grpc.pb.go.go
@@ -396,6 +396,26 @@ func (mr *MockLessonServiceClientMockRecorder) ListTeacherSubmissionsByShiftSumm
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTeacherSubmissionsByShiftSummaryIDs", reflect.TypeOf((*MockLessonServiceClient)(nil).ListTeacherSubmissionsByShiftSummaryIDs), varargs...)
 }
 
+// ListTeacherSubmissionsByTeacherIDs mocks base method.
+func (m *MockLessonServiceClient) ListTeacherSubmissionsByTeacherIDs(ctx context.Context, in *lesson.ListTeacherSubmissionsByTeacherIDsRequest, opts ...grpc.CallOption) (*lesson.ListTeacherSubmissionsByTeacherIDsResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListTeacherSubmissionsByTeacherIDs", varargs...)
+	ret0, _ := ret[0].(*lesson.ListTeacherSubmissionsByTeacherIDsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListTeacherSubmissionsByTeacherIDs indicates an expected call of ListTeacherSubmissionsByTeacherIDs.
+func (mr *MockLessonServiceClientMockRecorder) ListTeacherSubmissionsByTeacherIDs(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTeacherSubmissionsByTeacherIDs", reflect.TypeOf((*MockLessonServiceClient)(nil).ListTeacherSubmissionsByTeacherIDs), varargs...)
+}
+
 // UpdateLesson mocks base method.
 func (m *MockLessonServiceClient) UpdateLesson(ctx context.Context, in *lesson.UpdateLessonRequest, opts ...grpc.CallOption) (*lesson.UpdateLessonResponse, error) {
 	m.ctrl.T.Helper()
@@ -807,6 +827,21 @@ func (m *MockLessonServiceServer) ListTeacherSubmissionsByShiftSummaryIDs(arg0 c
 func (mr *MockLessonServiceServerMockRecorder) ListTeacherSubmissionsByShiftSummaryIDs(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTeacherSubmissionsByShiftSummaryIDs", reflect.TypeOf((*MockLessonServiceServer)(nil).ListTeacherSubmissionsByShiftSummaryIDs), arg0, arg1)
+}
+
+// ListTeacherSubmissionsByTeacherIDs mocks base method.
+func (m *MockLessonServiceServer) ListTeacherSubmissionsByTeacherIDs(arg0 context.Context, arg1 *lesson.ListTeacherSubmissionsByTeacherIDsRequest) (*lesson.ListTeacherSubmissionsByTeacherIDsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListTeacherSubmissionsByTeacherIDs", arg0, arg1)
+	ret0, _ := ret[0].(*lesson.ListTeacherSubmissionsByTeacherIDsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListTeacherSubmissionsByTeacherIDs indicates an expected call of ListTeacherSubmissionsByTeacherIDs.
+func (mr *MockLessonServiceServerMockRecorder) ListTeacherSubmissionsByTeacherIDs(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTeacherSubmissionsByTeacherIDs", reflect.TypeOf((*MockLessonServiceServer)(nil).ListTeacherSubmissionsByTeacherIDs), arg0, arg1)
 }
 
 // UpdateLesson mocks base method.

--- a/api/proto/lesson/service.proto
+++ b/api/proto/lesson/service.proto
@@ -29,6 +29,7 @@ service LessonService {
   rpc ListShifts(ListShiftsRequest) returns (ListShiftsResponse);
   rpc CreateShifts(CreateShiftsRequest) returns (CreateShiftsResponse);
   rpc ListSubmissions(ListSubmissionsRequest) returns (ListSubmissionsResponse);
+  rpc ListTeacherSubmissionsByTeacherIDs(ListTeacherSubmissionsByTeacherIDsRequest) returns (ListTeacherSubmissionsByTeacherIDsResponse);
   rpc ListTeacherSubmissionsByShiftSummaryIDs(ListTeacherSubmissionsByShiftSummaryIDsRequest) returns (ListTeacherSubmissionsByShiftSummaryIDsResponse);
   rpc ListTeacherShifts(ListTeacherShiftsRequest) returns (ListTeacherShiftsResponse);
   rpc GetTeacherShifts(GetTeacherShiftsRequest) returns (GetTeacherShiftsResponse);
@@ -176,6 +177,15 @@ message ListSubmissionsRequest {
 message ListSubmissionsResponse {
   repeated TeacherShift teacher_shifts = 1;
   repeated StudentShift student_shifts = 2;
+}
+
+message ListTeacherSubmissionsByTeacherIDsRequest {
+  repeated string teacher_ids      = 1 [(validate.rules).repeated = { unique: true, items: { string: { min_len: 1 }}}];
+  int64           shift_summary_id = 2 [(validate.rules).int64 = { gt: 0 }];
+}
+
+message ListTeacherSubmissionsByTeacherIDsResponse {
+  repeated TeacherSubmission submissions = 1;
 }
 
 message ListTeacherSubmissionsByShiftSummaryIDsRequest {


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
講師ID一覧をもとに提出されたシフト一覧を取得するAPIを実装しました。

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->
* [ ] クライアント実装
* [x] Lesson API周りの実装
* [ ] Gateway周りの実装

## 備考

<!-- マージ後に必要な操作などがあればここに -->
* https://github.com/calmato/shs-web/issues/317