### PR TITLE
fix: メニューの表示がずれないように修正

### DIFF
--- a/web/student/src/components/organisms/TheHeader.vue
+++ b/web/student/src/components/organisms/TheHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app-bar app dark clipped-left color="primary" class="px-2">
+  <v-app-bar app dark clipped-left color="primary" class="px-2 header">
     <v-toolbar-title>SHS Web</v-toolbar-title>
     <v-spacer />
     <v-btn v-show="showMenu" class="hidden-md-and-up" icon @click="onClick">
@@ -35,3 +35,9 @@ export default defineComponent({
   },
 })
 </script>
+
+<style lang="scss" scoped>
+.header {
+  z-index: 10;
+}
+</style>

--- a/web/student/src/components/organisms/TheMenu.vue
+++ b/web/student/src/components/organisms/TheMenu.vue
@@ -1,6 +1,6 @@
 <template>
   <v-overlay :value="overlay" :absolute="absolute" class="align-start">
-    <v-row align="start" class="py-8">
+    <v-row align="start" class="py-8 ma-0 mt-4">
       <v-col v-for="item in items" :key="item.name" cols="4" md="3" align="center" class="py-8">
         <v-btn dark icon x-large @click="onClickItem(item)">
           <div class="d-flex flex-column align-center">

--- a/web/student/src/layouts/default.vue
+++ b/web/student/src/layouts/default.vue
@@ -7,7 +7,7 @@
       <nuxt />
       <the-menu
         :overlay="overlay"
-        :absolute="true"
+        :absolute="false"
         :items="items"
         @click:item="handleClickMenuItem"
         @click:close="handleClickMenu"

--- a/web/teacher/src/components/organisms/TheHeader.vue
+++ b/web/teacher/src/components/organisms/TheHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app-bar app dark clipped-left color="primary" class="px-2">
+  <v-app-bar app dark clipped-left color="primary" class="px-2 header">
     <v-toolbar-title>SHS Web</v-toolbar-title>
     <v-spacer />
     <v-btn v-show="showMenu" class="hidden-md-and-up" icon @click="onClick">
@@ -35,3 +35,9 @@ export default defineComponent({
   },
 })
 </script>
+
+<style lang="scss" scoped>
+.header {
+  z-index: 10;
+}
+</style>

--- a/web/teacher/src/components/organisms/TheMenu.vue
+++ b/web/teacher/src/components/organisms/TheMenu.vue
@@ -1,6 +1,6 @@
 <template>
   <v-overlay :value="overlay" :absolute="absolute" class="align-start">
-    <v-row align="start" class="py-8">
+    <v-row align="start" class="py-8 ma-0 mt-4">
       <v-col v-for="item in items" :key="item.name" cols="4" md="3" align="center" class="py-8">
         <v-btn dark icon x-large @click="onClickItem(item)">
           <div class="d-flex flex-column align-center">

--- a/web/teacher/src/layouts/default.vue
+++ b/web/teacher/src/layouts/default.vue
@@ -7,7 +7,7 @@
       <nuxt />
       <the-menu
         :overlay="overlay"
-        :absolute="true"
+        :absolute="false"
         :items="getMenuItems()"
         @click:item="handleClickMenuItem"
         @click:close="handleClickMenu"


### PR DESCRIPTION
## やったこと

- メニューがずれないようにした。

![shs-web](https://user-images.githubusercontent.com/27722351/154838586-233cbf4c-0bb7-4ea4-a5dc-17621a2bf412.gif)

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
* closes: https://github.com/calmato/shs-web/issues/321